### PR TITLE
Fix to installation on Windows.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,6 @@ dependencies = [
   "lxml>=6.0.1",
   "markupsafe>=3.0.3",
   "matplotlib>=3.10.6",
-  "mlx>=0.30.6",
-  "mlx-lm>=0.30.7",
-  "mlx-vlm>=0.4.4",
-  "mlx-metal>=0.30.6",
   "nodeenv>=1.9.1",
   "numpy>=2.3.3",
   "ollama>=0.6.0",
@@ -67,6 +63,10 @@ dependencies = [
   "urllib3>=2.5.0",
   "virtualenv>=20.34.0",
   "torchvision>=0.26.0",
+  "mlx>=0.30.6; sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "mlx-lm>=0.30.7; sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "mlx-vlm>=0.4.4; sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "mlx-metal>=0.30.6; sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Added the four MLX packages with PEP 508 markers gating them to macOS on Apple Silicon. On Windows/Linux-x86 `uv sync` will simply skip them; on an M-series Mac they'll install normally.