### PR TITLE
Add a web UI: live benchmark runs, endpoint management, interactive comparisons and rich exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ $RECYCLE.BIN/
 *.lnk
 
 .mypy_cache
+
+# Web UI
+webui_endpoints.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ uv run benchmark -- llamacpp <model> --host localhost --port 8080
 uv run benchmark -- <engine> <model> --contexts 2,4,8,16 --max-tokens 500 --timeout 7200
 
 uv run compare-benchmarks            # Compare benchmark results
+uv run benchmark-webui               # Web UI on http://127.0.0.1:8321
 uv run generate-context-files -- <source.txt> --sizes 2,4,8,16,32,64,128
 ```
 
@@ -35,6 +36,7 @@ There are no automated tests in this project.
 - **`benchmark_common.py`** — Shared library used by all engines. Provides: hardware detection, context file discovery, CLI argument setup (`setup_common_args()`), result serialization (CSV, JSON, charts), chart generation (`create_chart_ollama()`, `create_chart_mlx()`), and summary formatting.
 - **`{engine}_benchmark.py`** — Engine-specific scripts (ollama_api, ollama_cli, mlx, mlx_distributed, llamacpp, lmstudio, exo, deepseek, grok, openai, vllm). Each follows: parse args → verify engine → collect hardware → warmup → iterate contexts → save outputs → print summary.
 - **`compare_benchmarks.py`** — Multi-benchmark comparison tool. Reads result directories, produces side-by-side charts/CSV/tables.
+- **`webui.py`** — FastAPI web UI (`benchmark-webui` entry point, serves `webui_static/`): routes, endpoints store (`webui_endpoints.json`, gitignored, 0600), results API. Companion modules: `webui_common.py` (paths/regexes), `webui_engines.py` (engine catalog + CLI command construction), `webui_runs.py` (subprocess run manager; children run with `PYTHONUNBUFFERED=1` so logs stream live). Writes a `webui_run.json` label file into each result folder. MLX-local engines (`mlx`, `mlx-vlm`, `mlx-distributed`, `paroquant`) are disabled on non-Apple-Silicon hosts. Frontend in `webui_static/`: `core.js` (state/router/helpers on `window.CB`), `charts.js` (SVG charts), `export.js` (ZIP/CSV/HTML/PDF builders), `report.js` (export pipeline), `view-*.js` (one module per view), `app.js` (bootstrap).
 - **`generate_context_files.py`** — Generates token-precise context files (`{size}k.txt`) using tiktoken.
 
 ## Key Conventions

--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ Engine-specific setup:
 pre-commit install
 ```
 
+## Web UI
+
+Everything the CLI does is also available in a local web UI — launching sweeps
+with live progress, named endpoints, browsing saved results, and interactive
+comparisons across any set of runs:
+
+```bash
+uv run benchmark-webui            # opens http://127.0.0.1:8321
+uv run benchmark-webui --host 0.0.0.0 --port 9000 --no-open
+```
+
+- **Run** — pick an engine, contexts, and options; watch prompt/generation
+  speed live per context. MLX engines are automatically disabled on machines
+  without Apple Silicon (e.g. NVIDIA boxes).
+- **Endpoints** — save named inference targets ("M3 Ultra · llama.cpp",
+  "DGX · vLLM"); the name labels the run in results and charts.
+- **Results** — every folder in `output/` with sparklines, details, rename
+  and delete.
+- **Compare** — select up to 8 runs and compare any metric (generation/prompt
+  t/s, TTFT, TPOT, memory, KV cache, batch sweeps) in interactive charts.
+
 ## Running Benchmarks
 
 ```bash

--- a/openai_benchmark.py
+++ b/openai_benchmark.py
@@ -58,6 +58,66 @@ def get_available_model(client: OpenAI) -> Optional[str]:
     return None
 
 
+class HostMemorySampler:
+    """Samples system RAM while a request runs. On Apple Silicon the unified
+    memory is also the GPU memory, so for a locally hosted server this is the
+    closest thing to server RAM/VRAM a client can observe. Only meaningful
+    when the endpoint runs on this machine (see is_local_base_url)."""
+
+    def __init__(self, interval: float = 0.2):
+        self.interval = interval
+        self.peak_bytes = 0
+        self._stop = None
+        self._thread = None
+
+    def __enter__(self):
+        import threading
+
+        import psutil
+
+        self._stop = threading.Event()
+
+        def sample():
+            while not self._stop.is_set():
+                used = psutil.virtual_memory().used
+                if used > self.peak_bytes:
+                    self.peak_bytes = used
+                self._stop.wait(self.interval)
+
+        self.peak_bytes = psutil.virtual_memory().used
+        self._thread = threading.Thread(target=sample, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._stop.set()
+        self._thread.join(timeout=2)
+        return False
+
+    @property
+    def peak_gb(self) -> float:
+        return round(self.peak_bytes / (1024**3), 2)
+
+
+def is_local_base_url(base_url: str) -> bool:
+    """True when the server runs on this machine (so host RAM sampling is meaningful)."""
+    import socket
+    from urllib.parse import urlparse
+
+    host = (urlparse(base_url).hostname or "").lower()
+    if host in ("127.0.0.1", "localhost", "::1", "0.0.0.0"):
+        return True
+    try:
+        return host in (socket.gethostname().lower(), socket.getfqdn().lower())
+    except OSError:
+        return False
+
+
+# Set from main() when the endpoint is local; run_benchmark/run_batch_benchmark
+# then record host_memory_gb (peak system RAM during the request).
+SAMPLE_HOST_MEMORY = False
+
+
 def run_benchmark(
     client: OpenAI,
     model: str,
@@ -94,6 +154,9 @@ def run_benchmark(
     server_gen_duration = 0.0
     peak_memory_gb = 0.0
 
+    host_mem_sampler = HostMemorySampler() if SAMPLE_HOST_MEMORY else None
+    if host_mem_sampler:
+        host_mem_sampler.__enter__()
     try:
         stream = client.chat.completions.create(
             model=model,
@@ -162,6 +225,9 @@ def run_benchmark(
     except Exception as e:
         print(f"Error during benchmark: {e}")
         return None
+    finally:
+        if host_mem_sampler:
+            host_mem_sampler.__exit__()
 
     end_time = time.time()
     total_time = end_time - start_time
@@ -230,6 +296,9 @@ def run_benchmark(
         result["reasoning_text"] = reasoning_text
     if peak_memory_gb > 0:
         result["peak_memory_gb"] = peak_memory_gb
+    if host_mem_sampler:
+        result["host_memory_gb"] = host_mem_sampler.peak_gb
+        print(f"  Host memory peak:   {host_mem_sampler.peak_gb:.2f} GB (system RAM, local server)")
 
     return common.add_throughput_metrics(result, prompt_text=prompt)
 
@@ -315,12 +384,22 @@ def run_batch_benchmark(
         trial_prompt_tps = []
         trial_gen_tps = []
         trial_peak_mem = []
+        trial_decode_tps = []  # pure decode rate summed across clients (from server usage)
 
+        trial_host_mem = []
         for trial in range(num_trials):
             start = time.time()
-            with concurrent.futures.ThreadPoolExecutor(max_workers=bs) as pool:
-                futures = [pool.submit(single_request) for _ in range(bs)]
-                responses = [f.result() for f in futures]
+            host_mem_sampler = HostMemorySampler() if SAMPLE_HOST_MEMORY else None
+            if host_mem_sampler:
+                host_mem_sampler.__enter__()
+            try:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=bs) as pool:
+                    futures = [pool.submit(single_request) for _ in range(bs)]
+                    responses = [f.result() for f in futures]
+            finally:
+                if host_mem_sampler:
+                    host_mem_sampler.__exit__()
+                    trial_host_mem.append(host_mem_sampler.peak_gb)
             wall_time = time.time() - start
 
             total_prompt_tok = sum(r["prompt_tokens"] for r in responses)
@@ -334,6 +413,14 @@ def run_batch_benchmark(
             if peak_mem > 0:
                 trial_peak_mem.append(peak_mem)
 
+            # Pure decode throughput: the server reports each request's own
+            # generation_tps (decode phase only). Summed across the N parallel
+            # clients this is the aggregate decode rate, independent of how
+            # long the prompt phase took.
+            per_request_decode = [r["generation_tps"] for r in responses if r.get("generation_tps")]
+            if len(per_request_decode) == len(responses):
+                trial_decode_tps.append(sum(per_request_decode))
+
             print(f"    Trial {trial + 1}: pp {agg_prompt_tps:.1f} tg {agg_gen_tps:.1f} t/s ({wall_time:.1f}s)")
 
         if trial_prompt_tps:
@@ -344,6 +431,12 @@ def run_batch_benchmark(
                 "prompt_tps": round(avg_prompt, 2),
                 "generation_tps": round(avg_gen, 2),
             }
+            if trial_decode_tps:
+                avg_decode = statistics.mean(trial_decode_tps)
+                result["decode_tps_total"] = round(avg_decode, 2)
+                result["decode_tps_per_client"] = round(avg_decode / bs, 2)
+            if trial_host_mem:
+                result["host_memory_gb"] = round(max(trial_host_mem), 2)
             if trial_peak_mem:
                 result["peak_memory_gb"] = round(max(trial_peak_mem), 3)
             else:
@@ -424,6 +517,12 @@ def main() -> int:
     args = parser.parse_args()
 
     base_url = args.base_url.rstrip("/")
+
+    # host RAM/VRAM sampling is only meaningful when the server is local
+    global SAMPLE_HOST_MEMORY
+    SAMPLE_HOST_MEMORY = is_local_base_url(base_url)
+    if SAMPLE_HOST_MEMORY:
+        print("Local endpoint detected — sampling host memory (RAM/VRAM) during requests.")
     client = build_client(base_url, args.api_key)
 
     print(f"Testing connection to {base_url} ...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "cycler>=0.12.1",
   "datasets>=4.8.5",
   "distlib>=0.4.0",
+  "fastapi>=0.115.0",
   "filelock>=3.29.0",
   "fonttools>=4.62.1",
   "fsspec>=2026.2.0",
@@ -65,12 +66,14 @@ dependencies = [
   "typing-inspection>=0.4.2",
   "tzdata>=2026.2",
   "urllib3>=2.6.3",
+  "uvicorn>=0.30.0",
   "virtualenv>=21.3.0",
   "torchvision>=0.26.0",
 ]
 
 [project.scripts]
 benchmark = "benchmark:main"
+benchmark-webui = "webui:main"
 compare-benchmarks = "compare_benchmarks:main"
 generate-context-files = "generate_context_files:main"
 ollama-api-benchmark = "ollama_api_benchmark:main"
@@ -125,4 +128,8 @@ py-modules = [
   "regen_charts",
   "paroquant_benchmark",
   "vllm_benchmark",
+  "webui",
+  "webui_common",
+  "webui_engines",
+  "webui_runs",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -863,6 +863,7 @@ dependencies = [
     { name = "cycler" },
     { name = "datasets" },
     { name = "distlib" },
+    { name = "fastapi" },
     { name = "filelock" },
     { name = "fonttools" },
     { name = "fsspec" },
@@ -914,6 +915,7 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "tzdata" },
     { name = "urllib3" },
+    { name = "uvicorn" },
     { name = "virtualenv" },
 ]
 
@@ -929,6 +931,7 @@ requires-dist = [
     { name = "cycler", specifier = ">=0.12.1" },
     { name = "datasets", specifier = ">=4.8.5" },
     { name = "distlib", specifier = ">=0.4.0" },
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "filelock", specifier = ">=3.29.0" },
     { name = "fonttools", specifier = ">=4.62.1" },
     { name = "fsspec", specifier = ">=2026.2.0" },
@@ -980,6 +983,7 @@ requires-dist = [
     { name = "typing-inspection", specifier = ">=0.4.2" },
     { name = "tzdata", specifier = ">=2026.2" },
     { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
     { name = "virtualenv", specifier = ">=21.3.0" },
 ]
 

--- a/webui.py
+++ b/webui.py
@@ -1,0 +1,480 @@
+"""
+Web UI for the LLM context benchmark toolkit.
+
+Serves a single-page app that can launch any registered benchmark engine,
+watch runs live, manage named endpoints, browse saved results in output/
+and build interactive comparisons across any set of runs.
+
+Companion modules: webui_common (paths), webui_engines (engine catalog +
+command construction), webui_runs (subprocess run manager).
+
+Usage:
+    uv run benchmark-webui                # http://127.0.0.1:8321
+    uv run benchmark-webui --port 9000 --host 0.0.0.0
+    python webui.py --no-open
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import threading
+import time
+import uuid
+import webbrowser
+from datetime import datetime
+from pathlib import Path
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+import benchmark_common
+from compare_benchmarks import parse_benchmark_folder
+from webui_common import (
+    CONTEXT_FILE_RE,
+    ENDPOINTS_FILE,
+    FOLDER_TS_RE,
+    OUTPUT_DIR,
+    ROOT,
+    RUN_META_FILE,
+    STATIC_DIR,
+    is_apple_silicon,
+)
+from webui_engines import build_command, engine_available, get_engine_catalog
+from webui_runs import RunManager
+
+run_manager = RunManager()
+
+
+# ---------------------------------------------------------------------------
+# Endpoints store
+# ---------------------------------------------------------------------------
+
+
+def load_endpoints() -> list:
+    if ENDPOINTS_FILE.exists():
+        try:
+            os.chmod(ENDPOINTS_FILE, 0o600)  # may contain API keys
+            return json.loads(ENDPOINTS_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            return []
+    return []
+
+
+def save_endpoints(endpoints: list):
+    # owner-only: the file may contain API keys
+    fd = os.open(str(ENDPOINTS_FILE), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, json.dumps(endpoints, indent=2).encode())
+    finally:
+        os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+
+def read_run_meta(folder: Path) -> dict:
+    meta_path = folder / RUN_META_FILE
+    if meta_path.exists():
+        try:
+            return json.loads(meta_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def context_sort_key(ctx: str) -> float:
+    try:
+        return float(str(ctx).rstrip("k"))
+    except ValueError:
+        return 0.0
+
+
+def folder_timestamp(name: str):
+    m = FOLDER_TS_RE.search(name)
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%Y%m%d_%H%M%S").isoformat(timespec="seconds")
+        except ValueError:
+            pass
+    return None
+
+
+def summarize_result_folder(folder: Path):
+    parsed, _ = parse_benchmark_folder(folder)
+    if not parsed:
+        return None
+    meta = read_run_meta(folder)
+    rows = sorted(parsed["results"], key=lambda r: context_sort_key(r.get("context_size", "0")))
+    hw = parsed["hardware_info"] or {}
+    gen_series = [
+        [context_sort_key(r["context_size"]), r.get("generation_tps")]
+        for r in rows
+        if isinstance(r.get("generation_tps"), float)
+    ]
+    gen_values = [v for _, v in gen_series]
+    charts = sorted(p.name for p in folder.glob("*.png"))
+    return {
+        "folder": folder.name,
+        "engine": parsed["engine"],
+        "model": parsed["model"],
+        "cache_mode": parsed["cache_mode"],
+        "label": meta.get("label") or "",
+        "endpoint": meta.get("endpoint") or "",
+        "timestamp": folder_timestamp(folder.name),
+        "machine": hw.get("chip") or hw.get("machine_label") or hw.get("processor") or "",
+        "hardware": benchmark_common.format_hardware_string(hw) if hw else "",
+        "contexts": [r.get("context_size") for r in rows],
+        "peak_generation_tps": max(gen_values) if gen_values else None,
+        "gen_series": gen_series,
+        "columns": sorted({k for r in rows for k in r.keys()}),
+        "has_batch": bool(parsed["batch_data"]),
+        "has_perplexity": bool(parsed["perplexity_data"]),
+        "has_cached": bool(parsed["cached_results"]),
+        "charts": charts,
+    }
+
+
+def resolve_result_folder(name: str) -> Path:
+    if "/" in name or "\\" in name or name.startswith(".") or not name.startswith("benchmark_"):
+        raise HTTPException(400, "Invalid result folder name")
+    folder = OUTPUT_DIR / name
+    if not folder.is_dir():
+        raise HTTPException(404, f"Result folder '{name}' not found")
+    return folder
+
+
+# ---------------------------------------------------------------------------
+# App / routes
+# ---------------------------------------------------------------------------
+
+app = FastAPI(title="LLM Context Bench", docs_url=None, redoc_url=None)
+
+
+@app.get("/api/meta")
+def api_meta():
+    catalog = get_engine_catalog()
+    engines = []
+    for engine_id, info in catalog.items():
+        engines.append(
+            {
+                "id": engine_id,
+                "label": info["label"],
+                "description": info["description"],
+                "example": info["example"],
+                "model": info["model"],
+                "connection": info["connection"],
+                "default_base_url": info.get("default_base_url", ""),
+                "default_contexts": info.get("default_contexts", "0.5,1,2,4,8,16,32"),
+                "cold_prefill": info["cold_prefill"],
+                "local_mlx": info["local_mlx"],
+                "available": engine_available(info),
+                "options": info["options"],
+            }
+        )
+    context_files = []
+    for path in sorted(ROOT.glob("*.txt")):
+        m = CONTEXT_FILE_RE.match(path.stem)
+        if m:
+            context_files.append({"size": float(m.group(1)), "name": path.stem, "file": path.name})
+    context_files.sort(key=lambda c: c["size"])
+    source_files = sorted(p.name for p in ROOT.glob("*.txt") if not CONTEXT_FILE_RE.match(p.stem))
+    hw = benchmark_common.get_hardware_info()
+    return {
+        "engines": engines,
+        "mlx_available": is_apple_silicon(),
+        "hardware": hw,
+        "hardware_string": benchmark_common.format_hardware_string(hw),
+        "context_files": context_files,
+        "source_files": source_files,
+    }
+
+
+@app.get("/api/endpoints")
+def api_endpoints_list():
+    return load_endpoints()
+
+
+@app.post("/api/endpoints")
+def api_endpoints_create(payload: dict):
+    name = (payload.get("name") or "").strip()
+    if not name:
+        raise HTTPException(400, "Endpoint name is required")
+    endpoints = load_endpoints()
+    entry = {
+        "id": uuid.uuid4().hex[:10],
+        "name": name,
+        "engine": payload.get("engine") or "",
+        "model": payload.get("model") or "",
+        "base_url": payload.get("base_url") or "",
+        "api_key": payload.get("api_key") or "",
+        "host": payload.get("host") or "",
+        "port": payload.get("port") or "",
+        "notes": payload.get("notes") or "",
+    }
+    endpoints.append(entry)
+    save_endpoints(endpoints)
+    return entry
+
+
+@app.put("/api/endpoints/{endpoint_id}")
+def api_endpoints_update(endpoint_id: str, payload: dict):
+    endpoints = load_endpoints()
+    for entry in endpoints:
+        if entry["id"] == endpoint_id:
+            for key in ("name", "engine", "model", "base_url", "api_key", "host", "port", "notes"):
+                if key in payload:
+                    entry[key] = payload[key]
+            if not (entry.get("name") or "").strip():
+                raise HTTPException(400, "Endpoint name is required")
+            save_endpoints(endpoints)
+            return entry
+    raise HTTPException(404, "Endpoint not found")
+
+
+@app.post("/api/models")
+def api_models(payload: dict):
+    """Discover available models on an inference server (OpenAI /v1/models or Ollama /api/tags)."""
+    engine = payload.get("engine") or ""
+    base_url = (payload.get("base_url") or "").strip()
+    host = (payload.get("host") or "").strip()
+    port = payload.get("port") or ""
+    api_key = (payload.get("api_key") or "").strip()
+
+    if engine in ("ollama-api", "ollama-cli"):
+        url, flavor = "http://127.0.0.1:11434/api/tags", "ollama"
+    elif host:
+        url, flavor = f"http://{host}:{port or 8080}/v1/models", "openai"
+    elif base_url:
+        trimmed = base_url.rstrip("/")
+        url = trimmed + "/models" if trimmed.endswith("/v1") else trimmed + "/v1/models"
+        flavor = "openai"
+    else:
+        return {"models": [], "detail": "No connection configured"}
+
+    headers = {"User-Agent": "context-bench-webui"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        import httpx
+
+        response = httpx.get(url, timeout=5.0, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+        if flavor == "ollama":
+            models = [m.get("name") or m.get("model") for m in data.get("models", [])]
+        else:
+            models = [m.get("id") for m in data.get("data", [])]
+        models = sorted({m for m in models if m})
+        return {"models": models}
+    except Exception as exc:
+        return {"models": [], "detail": f"{exc.__class__.__name__}: {exc}"}
+
+
+@app.post("/api/endpoints/{endpoint_id}/ping")
+def api_endpoints_ping(endpoint_id: str):
+    endpoint = next((e for e in load_endpoints() if e["id"] == endpoint_id), None)
+    if endpoint is None:
+        raise HTTPException(404, "Endpoint not found")
+    url = (endpoint.get("base_url") or "").strip()
+    if not url and endpoint.get("host"):
+        url = f"http://{endpoint['host']}:{endpoint.get('port') or 8080}/health"
+    if not url:
+        return {"ok": None, "detail": "No URL configured — local engine"}
+    started = time.time()
+    try:
+        import httpx
+
+        response = httpx.get(url, timeout=3.0, headers={"User-Agent": "context-bench-webui"})
+        latency_ms = round((time.time() - started) * 1000)
+        # any HTTP response means the server is up; auth errors etc. still count
+        return {"ok": True, "status": response.status_code, "latency_ms": latency_ms}
+    except Exception as exc:
+        return {"ok": False, "detail": exc.__class__.__name__, "latency_ms": round((time.time() - started) * 1000)}
+
+
+@app.delete("/api/endpoints/{endpoint_id}")
+def api_endpoints_delete(endpoint_id: str):
+    endpoints = load_endpoints()
+    remaining = [e for e in endpoints if e["id"] != endpoint_id]
+    if len(remaining) == len(endpoints):
+        raise HTTPException(404, "Endpoint not found")
+    save_endpoints(remaining)
+    return {"ok": True}
+
+
+@app.get("/api/runs")
+def api_runs_list():
+    return run_manager.list_runs()
+
+
+@app.post("/api/runs")
+def api_runs_start(payload: dict):
+    engine_id = payload.get("engine")
+    catalog = get_engine_catalog()
+    if engine_id not in catalog:
+        raise HTTPException(400, f"Unknown engine '{engine_id}'")
+
+    endpoint_name = ""
+    endpoint_id = payload.get("endpoint_id")
+    if endpoint_id:
+        endpoint = next((e for e in load_endpoints() if e["id"] == endpoint_id), None)
+        if endpoint:
+            endpoint_name = endpoint["name"]
+
+    argv, contexts = build_command(engine_id, payload)
+    label = (payload.get("label") or "").strip() or endpoint_name
+    run = run_manager.start(
+        "benchmark",
+        engine_id,
+        catalog[engine_id]["tag"],
+        (payload.get("model") or "").strip() or "(auto)",
+        label,
+        endpoint_name,
+        argv,
+        contexts,
+    )
+    return run.snapshot()
+
+
+@app.post("/api/source-files")
+async def api_source_upload(request: Request, name: str):
+    """Accept a raw .txt upload as a new source text for generate-context-files."""
+    safe = Path(name).name
+    if not safe.lower().endswith(".txt"):
+        raise HTTPException(400, "Only .txt files are supported")
+    if CONTEXT_FILE_RE.match(Path(safe).stem):
+        raise HTTPException(400, "That name collides with generated context files ({size}k.txt)")
+    body = await request.body()
+    if not body:
+        raise HTTPException(400, "The uploaded file is empty")
+    if len(body) > 100 * 1024 * 1024:
+        raise HTTPException(400, "File too large (max 100 MB)")
+    (ROOT / safe).write_bytes(body)
+    return {"ok": True, "name": safe}
+
+
+@app.post("/api/context-files")
+def api_context_files_generate(payload: dict):
+    source = (payload.get("source") or "").strip()
+    sizes = (payload.get("sizes") or "").strip()
+    if not source:
+        raise HTTPException(400, "Source file is required")
+    source_path = ROOT / Path(source).name
+    if not source_path.exists():
+        raise HTTPException(404, f"Source file '{source}' not found")
+    argv = [sys.executable, str(ROOT / "generate_context_files.py"), str(source_path)]
+    if sizes:
+        argv += ["--sizes", sizes]
+    run = run_manager.start(
+        "ctxgen",
+        "context-files",
+        "",
+        source_path.name,
+        "Context files",
+        "",
+        argv,
+        [s.strip() for s in sizes.split(",") if s.strip()],
+    )
+    return run.snapshot()
+
+
+@app.get("/api/runs/{run_id}")
+def api_runs_get(run_id: str, offset: int = 0):
+    run = run_manager.get(run_id)
+    lines, next_offset = run.log_slice(max(0, offset))
+    snapshot = run.snapshot()
+    snapshot["log"] = lines
+    snapshot["next_offset"] = next_offset
+    return snapshot
+
+
+@app.post("/api/runs/{run_id}/stop")
+def api_runs_stop(run_id: str):
+    return run_manager.stop(run_id).snapshot()
+
+
+@app.get("/api/results")
+def api_results_list():
+    if not OUTPUT_DIR.is_dir():
+        return []
+    summaries = []
+    for folder in sorted(OUTPUT_DIR.iterdir()):
+        if folder.is_dir() and folder.name.startswith("benchmark_"):
+            try:
+                summary = summarize_result_folder(folder)
+            except Exception as exc:  # a single broken folder must not kill the list
+                summary = {"folder": folder.name, "error": str(exc)}
+            if summary:
+                summaries.append(summary)
+    summaries.sort(key=lambda s: s.get("timestamp") or "", reverse=True)
+    return summaries
+
+
+@app.get("/api/results/{name}")
+def api_results_detail(name: str):
+    folder = resolve_result_folder(name)
+    parsed, _ = parse_benchmark_folder(folder)
+    if not parsed:
+        raise HTTPException(404, f"'{name}' has no benchmark_results.csv")
+    summary = summarize_result_folder(folder)
+    files = sorted(p.name for p in folder.iterdir() if p.is_file())
+    return {
+        "summary": summary,
+        "results": sorted(parsed["results"], key=lambda r: context_sort_key(r.get("context_size", "0"))),
+        "hardware_info": parsed["hardware_info"],
+        "batch_data": parsed["batch_data"],
+        "perplexity_data": parsed["perplexity_data"],
+        "cached_results": parsed["cached_results"],
+        "files": files,
+    }
+
+
+@app.patch("/api/results/{name}")
+def api_results_label(name: str, payload: dict):
+    folder = resolve_result_folder(name)
+    meta = read_run_meta(folder)
+    meta["label"] = (payload.get("label") or "").strip()
+    (folder / RUN_META_FILE).write_text(json.dumps(meta, indent=2))
+    return {"ok": True, "label": meta["label"]}
+
+
+@app.delete("/api/results/{name}")
+def api_results_delete(name: str):
+    folder = resolve_result_folder(name)
+    shutil.rmtree(folder)
+    return {"ok": True}
+
+
+app.mount("/output", StaticFiles(directory=str(OUTPUT_DIR), check_dir=False), name="output")
+app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+
+@app.get("/")
+def index():
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Web UI for the LLM context benchmark toolkit")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8321, help="Bind port (default: 8321)")
+    parser.add_argument("--no-open", action="store_true", help="Don't open the browser on start")
+    args = parser.parse_args()
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    url = f"http://{args.host}:{args.port}"
+    print(f"LLM Context Bench UI on {url}")
+    if not args.no_open:
+        threading.Timer(0.8, lambda: webbrowser.open(url)).start()
+    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/webui_common.py
+++ b/webui_common.py
@@ -1,0 +1,18 @@
+"""Shared constants and small helpers for the web UI modules."""
+
+import platform
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+OUTPUT_DIR = ROOT / "output"
+STATIC_DIR = ROOT / "webui_static"
+ENDPOINTS_FILE = ROOT / "webui_endpoints.json"
+RUN_META_FILE = "webui_run.json"
+
+CONTEXT_FILE_RE = re.compile(r"^(\d+(?:\.\d+)?)k$")
+FOLDER_TS_RE = re.compile(r"_(\d{8}_\d{6})$")
+
+
+def is_apple_silicon() -> bool:
+    return platform.system() == "Darwin" and platform.machine() == "arm64"

--- a/webui_engines.py
+++ b/webui_engines.py
@@ -1,0 +1,582 @@
+"""Engine catalog and benchmark-command construction for the web UI."""
+
+import sys
+
+from fastapi import HTTPException
+
+from webui_common import ROOT, is_apple_silicon
+
+
+def _batch_opts(sizes: str = "1,2,4,8") -> list:
+    return [
+        {
+            "key": "batch",
+            "type": "invflag",
+            "flag": "--no-batch",
+            "label": "Batch sweep",
+            "default": True,
+            "help": "Also run the continuous-batch benchmark",
+        },
+        {"key": "batch_sizes", "type": "str", "flag": "--batch-sizes", "label": "Batch sizes", "default": sizes},
+        {
+            "key": "batch_prompt_tokens",
+            "type": "int",
+            "flag": "--batch-prompt-tokens",
+            "label": "Batch prompt tokens",
+            "default": 2048,
+        },
+        {
+            "key": "batch_gen_tokens",
+            "type": "int",
+            "flag": "--batch-gen-tokens",
+            "label": "Batch gen tokens",
+            "default": 128,
+        },
+        {"key": "batch_trials", "type": "int", "flag": "--batch-trials", "label": "Batch trials", "default": 3},
+    ]
+
+
+def _sampling_opts(temperature: float = 0.7, stream: bool = True) -> list:
+    opts = [
+        {
+            "key": "temperature",
+            "type": "float",
+            "flag": "--temperature",
+            "label": "Temperature",
+            "default": temperature,
+        },
+        {"key": "top_p", "type": "float", "flag": "--top-p", "label": "Top-p", "default": 0.95},
+    ]
+    if stream:
+        opts.append({"key": "stream", "type": "optbool", "flag": "--stream", "label": "Streaming", "default": True})
+    return opts
+
+
+def _request_model_opt() -> dict:
+    return {
+        "key": "request_model",
+        "type": "str",
+        "flag": "--request-model",
+        "label": "Request model override",
+        "default": "",
+        "help": "Model name sent in the API request (defaults to the model field)",
+    }
+
+
+def get_engine_catalog() -> dict:
+    """Full engine catalog with everything the UI needs to build run forms."""
+    return {
+        "ollama-api": {
+            "label": "Ollama API",
+            "script": "ollama_api_benchmark.py",
+            "tag": "ollama_api",
+            "description": "Ollama Python API (local daemon)",
+            "example": "gpt-oss:20b",
+            "model": "required",
+            "connection": None,
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": _batch_opts(),
+        },
+        "ollama-cli": {
+            "label": "Ollama CLI",
+            "script": "ollama_cli_benchmark.py",
+            "tag": "ollama_cli",
+            "description": "Ollama CLI with verbose output",
+            "example": "llama3.2",
+            "model": "required",
+            "connection": None,
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": _batch_opts(),
+        },
+        "llamacpp": {
+            "label": "llama.cpp",
+            "script": "llamacpp_benchmark.py",
+            "tag": "llamacpp",
+            "description": "llama.cpp server via HTTP API",
+            "example": "gpt-oss:20b",
+            "model": "required",
+            "connection": "hostport",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [
+                {
+                    "key": "server_hardware",
+                    "type": "str",
+                    "flag": "--server-hardware",
+                    "label": "Server hardware label",
+                    "default": "",
+                },
+                {
+                    "key": "server_memory_gb",
+                    "type": "float",
+                    "flag": "--server-memory-gb",
+                    "label": "Server memory (GB)",
+                    "default": None,
+                },
+                {
+                    "key": "server_cores",
+                    "type": "int",
+                    "flag": "--server-cores",
+                    "label": "Server cores",
+                    "default": None,
+                },
+            ],
+        },
+        "lmstudio": {
+            "label": "LM Studio",
+            "script": "lmstudio_benchmark.py",
+            "tag": "lmstudio",
+            "description": "LM Studio local server",
+            "example": "local-model",
+            "model": "auto",
+            "connection": "base_url",
+            "default_base_url": "http://localhost:1234",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": _batch_opts(),
+        },
+        "exo": {
+            "label": "Exo",
+            "script": "exo_benchmark.py",
+            "tag": "exo",
+            "description": "Exo OpenAI-compatible endpoint",
+            "example": "local-model",
+            "model": "required",
+            "connection": "base_url",
+            "default_base_url": "http://0.0.0.0:52415",
+            "cold_prefill": False,
+            "local_mlx": False,
+            "options": [_request_model_opt()] + _sampling_opts(),
+        },
+        "openai": {
+            "label": "OpenAI-compatible",
+            "script": "openai_benchmark.py",
+            "tag": "openai_compat",
+            "description": "Generic OpenAI-compatible endpoint (vLLM, llama.cpp, ...)",
+            "example": "local-model",
+            "model": "auto",
+            "connection": "base_url",
+            "default_base_url": "http://localhost:8080/v1",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": _batch_opts(),
+        },
+        "vllm": {
+            "label": "vLLM",
+            "script": "vllm_benchmark.py",
+            "tag": "vllm",
+            "description": "vLLM server (streaming + /metrics + continuous batch)",
+            "example": "Qwen/Qwen3-8B",
+            "model": "required",
+            "connection": "base_url",
+            "default_base_url": "http://127.0.0.1:8000/v1",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": _sampling_opts()
+            + [
+                {"key": "metrics", "type": "optbool", "flag": "--metrics", "label": "Scrape /metrics", "default": True},
+                {
+                    "key": "metrics_base_url",
+                    "type": "str",
+                    "flag": "--metrics-base-url",
+                    "label": "Metrics base URL",
+                    "default": "",
+                },
+            ]
+            + _batch_opts(),
+        },
+        "deepseek": {
+            "label": "DeepSeek",
+            "script": "deepseek_benchmark.py",
+            "tag": "deepseek",
+            "description": "DeepSeek cloud API",
+            "example": "deepseek-chat",
+            "model": "required",
+            "connection": "base_url",
+            "default_base_url": "https://api.deepseek.com/v1",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [_request_model_opt()] + _sampling_opts(),
+        },
+        "grok": {
+            "label": "Grok",
+            "script": "grok_benchmark.py",
+            "tag": "grok",
+            "description": "xAI Grok API",
+            "example": "grok-3",
+            "model": "required",
+            "connection": "base_url",
+            "default_base_url": "https://api.x.ai/v1",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [_request_model_opt()] + _sampling_opts(),
+        },
+        "afms": {
+            "label": "Apple Foundation",
+            "script": "apple_foundation_benchmark.py",
+            "tag": "afms",
+            "description": "Apple Foundation Models Serve endpoint",
+            "example": "system",
+            "model": "auto",
+            "connection": "base_url",
+            "default_base_url": "http://127.0.0.1:1976/v1",
+            "default_contexts": "0.5,1,2",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [
+                _request_model_opt(),
+                {
+                    "key": "temperature",
+                    "type": "float",
+                    "flag": "--temperature",
+                    "label": "Temperature",
+                    "default": 0.0,
+                },
+            ],
+        },
+        "mlx": {
+            "label": "MLX",
+            "script": "mlx_benchmark.py",
+            "tag": "mlx",
+            "description": "MLX framework (Apple Silicon only)",
+            "example": "mlx-community/Qwen3-0.6B-4bit",
+            "model": "required",
+            "connection": None,
+            "cold_prefill": False,
+            "local_mlx": True,
+            "options": [
+                {"key": "kv_bit", "type": "int", "flag": "--kv-bit", "label": "KV cache bits", "default": None},
+                {
+                    "key": "max_kv_size",
+                    "type": "int",
+                    "flag": "--max-kv-size",
+                    "label": "Max KV size (tokens)",
+                    "default": None,
+                },
+                {
+                    "key": "trust_remote_code",
+                    "type": "flag",
+                    "flag": "--trust-remote-code",
+                    "label": "Trust remote code",
+                    "default": False,
+                },
+                {
+                    "key": "ignore_chat_template",
+                    "type": "flag",
+                    "flag": "--ignore-chat-template",
+                    "label": "Ignore chat template",
+                    "default": False,
+                },
+                {
+                    "key": "cached",
+                    "type": "flag",
+                    "flag": "--cached",
+                    "label": "Cached-prefill sweep",
+                    "default": False,
+                },
+                {
+                    "key": "perplexity",
+                    "type": "invflag",
+                    "flag": "--no-perplexity",
+                    "label": "Perplexity",
+                    "default": True,
+                },
+                {
+                    "key": "kl_capture",
+                    "type": "invflag",
+                    "flag": "--no-kl-capture",
+                    "label": "KL capture",
+                    "default": True,
+                },
+            ]
+            + _batch_opts("1,2,4,8,16"),
+        },
+        "mlx-vlm": {
+            "label": "MLX-VLM",
+            "script": "mlx_vlm_benchmark.py",
+            "tag": "mlx_vlm",
+            "description": "MLX-VLM vision-language models (Apple Silicon)",
+            "example": "mlx-community/Qwen2.5-VL-7B-Instruct-4bit",
+            "model": "required",
+            "connection": None,
+            "cold_prefill": False,
+            "local_mlx": True,
+            "options": [
+                {"key": "kv_bits", "type": "float", "flag": "--kv-bits", "label": "KV cache bits", "default": None},
+                {
+                    "key": "kv_quant_scheme",
+                    "type": "choice",
+                    "flag": "--kv-quant-scheme",
+                    "label": "KV quant scheme",
+                    "default": "",
+                    "choices": ["", "uniform", "turboquant"],
+                },
+                {
+                    "key": "max_kv_size",
+                    "type": "int",
+                    "flag": "--max-kv-size",
+                    "label": "Max KV size (tokens)",
+                    "default": None,
+                },
+                {
+                    "key": "trust_remote_code",
+                    "type": "flag",
+                    "flag": "--trust-remote-code",
+                    "label": "Trust remote code",
+                    "default": False,
+                },
+            ]
+            + _batch_opts("1,2,4,8,16"),
+        },
+        "mlx-vlm-server": {
+            "label": "MLX-VLM Server",
+            "script": "mlx_vlm_server_benchmark.py",
+            "tag": "mlx_vlm_server",
+            "description": "mlx-vlm HTTP server (OpenAI-compatible)",
+            "example": "mlx-community/Qwen2.5-VL-7B-Instruct-4bit",
+            "model": "auto",
+            "connection": "base_url",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [_request_model_opt()]
+            + _sampling_opts(stream=False)
+            + [
+                {
+                    "key": "unload_between_rows",
+                    "type": "optbool",
+                    "flag": "--unload-between-rows",
+                    "label": "Unload between rows",
+                    "default": True,
+                },
+            ],
+        },
+        "omlx": {
+            "label": "oMLX",
+            "script": "omlx_benchmark.py",
+            "tag": "omlx",
+            "description": "oMLX inference server (OpenAI-compatible)",
+            "example": "gemma-4-26b-a4b-it-4bit",
+            "model": "required",
+            "connection": "base_url",
+            "default_base_url": "http://127.0.0.1:8000/v1",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [_request_model_opt()] + _sampling_opts() + _batch_opts(),
+        },
+        "mtplx": {
+            "label": "MTPLX",
+            "script": "mtplx_benchmark.py",
+            "tag": "mtplx",
+            "description": "MTPLX inference server (OpenAI-compatible)",
+            "example": "mtplx-qwen36-27b-optimized-speed",
+            "model": "auto",
+            "connection": "base_url",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [
+                _request_model_opt(),
+                {
+                    "key": "generation_mode",
+                    "type": "choice",
+                    "flag": "--generation-mode",
+                    "label": "Generation mode",
+                    "default": "",
+                    "choices": ["", "mtp", "ar"],
+                },
+                {
+                    "key": "clear_cache",
+                    "type": "optbool",
+                    "flag": "--clear-cache",
+                    "label": "Clear cache",
+                    "default": True,
+                },
+            ]
+            + _sampling_opts(temperature=0.6)
+            + _batch_opts(),
+        },
+        "dflash-mlx": {
+            "label": "DFlash MLX",
+            "script": "dflash_benchmark.py",
+            "tag": "dflash",
+            "description": "dflash-mlx speculative decoding (OpenAI-compatible)",
+            "example": "Qwen/Qwen3.6-27B",
+            "model": "auto",
+            "connection": "base_url",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [_request_model_opt()] + _sampling_opts(temperature=0.6, stream=False),
+        },
+        "vmlx": {
+            "label": "vMLX",
+            "script": "vmlx_benchmark.py",
+            "tag": "vmlx",
+            "description": "vMLX / MLX Studio server (OpenAI-compatible)",
+            "example": "mlx-community/Qwen3-8B-4bit",
+            "model": "required",
+            "connection": "base_url",
+            "default_base_url": "http://127.0.0.1:8001/v1",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [_request_model_opt()] + _sampling_opts() + _batch_opts(),
+        },
+        "paroquant": {
+            "label": "Paroquant",
+            "script": "paroquant_benchmark.py",
+            "tag": "paroquant",
+            "description": "Paroquant quantized inference (MLX, Apple Silicon)",
+            "example": "my-org/My-Model-PQ",
+            "model": "required",
+            "connection": None,
+            "cold_prefill": False,
+            "local_mlx": True,
+            "options": [
+                {
+                    "key": "ignore_chat_template",
+                    "type": "flag",
+                    "flag": "--ignore-chat-template",
+                    "label": "Ignore chat template",
+                    "default": False,
+                },
+                {
+                    "key": "perplexity",
+                    "type": "invflag",
+                    "flag": "--no-perplexity",
+                    "label": "Perplexity",
+                    "default": True,
+                },
+            ]
+            + _batch_opts("1,2,4,8,16"),
+        },
+        "mlx-distributed": {
+            "label": "MLX Distributed",
+            "script": "mlx_distributed_benchmark.py",
+            "tag": "mlx-distributed",
+            "description": "MLX distributed generate via mlx.launch (e.g. JACCL)",
+            "example": "/path/to/model",
+            "model": "required",
+            "connection": None,
+            "cold_prefill": False,
+            "local_mlx": True,
+            "options": [
+                {
+                    "key": "hostfile",
+                    "type": "str",
+                    "flag": "--hostfile",
+                    "label": "Hostfile (JSON)",
+                    "default": "",
+                    "required": True,
+                },
+                {"key": "backend", "type": "str", "flag": "--backend", "label": "Backend", "default": "jaccl"},
+                {"key": "launcher", "type": "str", "flag": "--launcher", "label": "Launcher", "default": "mlx.launch"},
+                {
+                    "key": "sharded_script",
+                    "type": "str",
+                    "flag": "--sharded-script",
+                    "label": "Sharded script",
+                    "default": "mlx_lm/examples/sharded_generate.py",
+                },
+                {
+                    "key": "pipeline",
+                    "type": "flag",
+                    "flag": "--pipeline",
+                    "label": "Pipeline parallelism",
+                    "default": False,
+                },
+            ],
+        },
+    }
+
+
+def engine_available(info: dict) -> bool:
+    if info.get("local_mlx") and not is_apple_silicon():
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Command building
+# ---------------------------------------------------------------------------
+
+
+def build_command(engine_id: str, payload: dict) -> tuple:
+    """Build the argv for a benchmark run. Returns (argv, contexts_list)."""
+    catalog = get_engine_catalog()
+    info = catalog.get(engine_id)
+    if info is None:
+        raise HTTPException(400, f"Unknown engine '{engine_id}'")
+    if not engine_available(info):
+        raise HTTPException(400, f"Engine '{engine_id}' requires Apple Silicon (MLX) and is disabled on this machine")
+
+    script = ROOT / info["script"]
+    if not script.exists():
+        raise HTTPException(500, f"Benchmark script {info['script']} not found")
+
+    argv = [sys.executable, str(script)]
+
+    model = (payload.get("model") or "").strip()
+    if model:
+        argv.append(model)
+    elif info["model"] == "required":
+        raise HTTPException(400, f"Engine '{engine_id}' requires a model")
+
+    contexts = (payload.get("contexts") or info.get("default_contexts") or "0.5,1,2,4,8,16,32").strip()
+    argv += ["--contexts", contexts]
+    argv += ["--max-tokens", str(int(payload.get("max_tokens") or 128))]
+    argv += ["--runs", str(int(payload.get("runs") or 2))]
+    argv += ["--timeout", str(int(payload.get("timeout") or 3600))]
+    if payload.get("save_responses"):
+        argv.append("--save-responses")
+
+    if info["cold_prefill"] and payload.get("cold_prefill") is False:
+        argv.append("--no-cold-prefill")
+
+    connection = payload.get("connection") or {}
+    if info["connection"] == "base_url":
+        base_url = (connection.get("base_url") or "").strip()
+        if base_url:
+            argv += ["--base-url", base_url]
+        api_key = (connection.get("api_key") or "").strip()
+        if api_key:
+            argv += ["--api-key", api_key]
+        if engine_id == "lmstudio" and connection.get("api_version"):
+            argv += ["--api-version", connection["api_version"]]
+    elif info["connection"] == "hostport":
+        if connection.get("host"):
+            argv += ["--host", str(connection["host"])]
+        if connection.get("port"):
+            argv += ["--port", str(int(connection["port"]))]
+
+    options = payload.get("options") or {}
+    for opt in info["options"]:
+        key = opt["key"]
+        value = options.get(key, opt.get("default"))
+        if opt.get("required") and (value is None or str(value).strip() == ""):
+            raise HTTPException(400, f"Option '{opt['label']}' is required for engine '{engine_id}'")
+        if value is None or (isinstance(value, str) and value.strip() == ""):
+            continue
+        kind = opt["type"]
+        if kind == "flag":
+            if value:
+                argv.append(opt["flag"])
+        elif kind == "invflag":
+            if not value:
+                argv.append(opt["flag"])
+        elif kind == "optbool":
+            if bool(value) != opt.get("default", True):
+                flag = opt["flag"]
+                argv.append(flag if value else flag.replace("--", "--no-", 1))
+        elif kind in ("int",):
+            argv += [opt["flag"], str(int(value))]
+        elif kind in ("float",):
+            argv += [opt["flag"], str(float(value))]
+        else:
+            argv += [opt["flag"], str(value)]
+
+    extra = (payload.get("extra_args") or "").strip()
+    if extra:
+        argv += extra.split()
+
+    context_list = [c.strip() for c in contexts.split(",") if c.strip()]
+    return argv, context_list

--- a/webui_runs.py
+++ b/webui_runs.py
@@ -1,0 +1,221 @@
+"""Subprocess run manager for the web UI: launches benchmark scripts,
+captures their output live and claims result folders."""
+
+import json
+import os
+import re
+import subprocess
+import threading
+import time
+import uuid
+from datetime import datetime
+
+from fastapi import HTTPException
+
+from webui_common import OUTPUT_DIR, ROOT, RUN_META_FILE
+
+PROGRESS_RE = re.compile(r"Benchmarking\s+([\d.]+k)\.txt")
+GEN_TPS_RES = [
+    re.compile(r"Generation:\s+\d+\s+tokens\s+in\s+[\d.]+s\s+=\s+([\d.]+)\s*t/s"),
+    re.compile(r"Generation TPS:\s+([\d.]+)"),
+    re.compile(r"generation_tps:\s+([\d.]+)"),
+]
+PROMPT_TPS_RES = [
+    re.compile(r"Prompt:\s+\d+\s+tokens\s+in\s+[\d.]+s\s+=\s+([\d.]+)\s*t/s"),
+    re.compile(r"Prompt TPS:\s+([\d.]+)"),
+]
+TTFT_RES = [
+    re.compile(r"Time to first token:\s+([\d.]+)s"),
+    re.compile(r"TTFT:\s+([\d.]+)s"),
+]
+
+SECRET_FLAGS = {"--api-key"}
+
+
+def redact_argv(argv: list) -> list:
+    out, hide = [], False
+    for arg in argv:
+        out.append("***" if hide else arg)
+        hide = arg in SECRET_FLAGS
+    return out
+
+
+class BenchmarkRun:
+    def __init__(self, run_id, kind, engine_id, tag, model, label, endpoint_name, argv, contexts):
+        self.id = run_id
+        self.kind = kind  # "benchmark" | "ctxgen"
+        self.engine = engine_id
+        self.tag = tag
+        self.model = model
+        self.label = label
+        self.endpoint_name = endpoint_name
+        self.argv = argv
+        self.contexts = contexts
+        self.status = "starting"
+        self.returncode = None
+        self.started = time.time()
+        self.finished = None
+        self.log_lines = []
+        self.lock = threading.Lock()
+        self.proc = None
+        self.stop_requested = False
+        self.current_context = None
+        self.contexts_done = 0
+        self.live = {}
+        self.result_folders = []
+        self.error = None
+
+    def snapshot(self):
+        with self.lock:
+            return {
+                "id": self.id,
+                "kind": self.kind,
+                "engine": self.engine,
+                "model": self.model,
+                "label": self.label,
+                "endpoint": self.endpoint_name,
+                "command": " ".join(redact_argv(self.argv)),
+                "status": self.status,
+                "returncode": self.returncode,
+                "started": self.started,
+                "finished": self.finished,
+                "elapsed": (self.finished or time.time()) - self.started,
+                "contexts": self.contexts,
+                "current_context": self.current_context,
+                "contexts_done": self.contexts_done,
+                "live": dict(self.live),
+                "result_folders": list(self.result_folders),
+                "error": self.error,
+                "log_length": len(self.log_lines),
+            }
+
+    def log_slice(self, offset):
+        with self.lock:
+            return self.log_lines[offset:], len(self.log_lines)
+
+
+class RunManager:
+    def __init__(self):
+        self.runs = {}
+        self.lock = threading.Lock()
+
+    def start(self, kind, engine_id, tag, model, label, endpoint_name, argv, contexts):
+        run = BenchmarkRun(uuid.uuid4().hex[:12], kind, engine_id, tag, model, label, endpoint_name, argv, contexts)
+        with self.lock:
+            self.runs[run.id] = run
+        thread = threading.Thread(target=self._execute, args=(run,), daemon=True)
+        thread.start()
+        return run
+
+    def get(self, run_id) -> BenchmarkRun:
+        with self.lock:
+            run = self.runs.get(run_id)
+        if run is None:
+            raise HTTPException(404, f"Unknown run '{run_id}'")
+        return run
+
+    def list_runs(self):
+        with self.lock:
+            runs = list(self.runs.values())
+        return sorted((r.snapshot() for r in runs), key=lambda r: r["started"], reverse=True)
+
+    def stop(self, run_id):
+        run = self.get(run_id)
+        with run.lock:
+            run.stop_requested = True
+            proc = run.proc
+        if proc and proc.poll() is None:
+            proc.terminate()
+            threading.Timer(10, lambda: proc.poll() is None and proc.kill()).start()
+        return run
+
+    def _execute(self, run: BenchmarkRun):
+        OUTPUT_DIR.mkdir(exist_ok=True)
+        before = {p.name for p in OUTPUT_DIR.iterdir() if p.is_dir()}
+        try:
+            # PYTHONUNBUFFERED: without it the child buffers stdout when piped,
+            # so the UI only sees output in 8 KB bursts instead of live lines.
+            proc = subprocess.Popen(
+                run.argv,
+                cwd=ROOT,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                env={**os.environ, "PYTHONUNBUFFERED": "1"},
+            )
+        except Exception as exc:
+            with run.lock:
+                run.status = "failed"
+                run.error = str(exc)
+                run.finished = time.time()
+            return
+
+        with run.lock:
+            run.proc = proc
+            run.status = "running"
+
+        seen_contexts = set()
+        for line in proc.stdout:
+            line = line.rstrip("\n")
+            with run.lock:
+                run.log_lines.append(line)
+                match = PROGRESS_RE.search(line)
+                if match:
+                    ctx = match.group(1)
+                    if run.current_context and run.current_context not in seen_contexts:
+                        seen_contexts.add(run.current_context)
+                    run.current_context = ctx
+                    run.contexts_done = len(seen_contexts)
+                for regex in GEN_TPS_RES:
+                    m = regex.search(line)
+                    if m:
+                        run.live["generation_tps"] = float(m.group(1))
+                        break
+                for regex in PROMPT_TPS_RES:
+                    m = regex.search(line)
+                    if m:
+                        run.live["prompt_tps"] = float(m.group(1))
+                        break
+                for regex in TTFT_RES:
+                    m = regex.search(line)
+                    if m:
+                        run.live["ttft"] = float(m.group(1))
+                        break
+        proc.wait()
+
+        folders = []
+        if run.kind == "benchmark":
+            try:
+                after = {p.name for p in OUTPUT_DIR.iterdir() if p.is_dir()}
+                prefix = f"benchmark_{run.tag}_"
+                for name in sorted(after - before):
+                    if not name.startswith(prefix):
+                        continue
+                    meta_path = OUTPUT_DIR / name / RUN_META_FILE
+                    if meta_path.exists():
+                        continue  # claimed by a concurrent run
+                    meta = {
+                        "run_id": run.id,
+                        "engine_id": run.engine,
+                        "label": run.label or "",
+                        "endpoint": run.endpoint_name or "",
+                        "created": datetime.now().isoformat(timespec="seconds"),
+                    }
+                    meta_path.write_text(json.dumps(meta, indent=2))
+                    folders.append(name)
+            except OSError:
+                pass
+
+        with run.lock:
+            run.returncode = proc.returncode
+            run.finished = time.time()
+            run.result_folders = folders
+            run.current_context = None
+            if run.stop_requested:
+                run.status = "stopped"
+            elif proc.returncode == 0:
+                run.status = "done"
+                run.contexts_done = len(run.contexts)
+            else:
+                run.status = "failed"

--- a/webui_static/app.js
+++ b/webui_static/app.js
@@ -1,0 +1,29 @@
+/* Context Bench bootstrap: loads meta + endpoints, fills the sidebar
+   readouts and hands control to the router. Views live in view-*.js. */
+
+(function () {
+  "use strict";
+
+  const { state, esc, api, initTheme, render } = CB;
+
+  async function boot() {
+    initTheme();
+    try {
+      state.meta = await api("/api/meta");
+      state.endpoints = await api("/api/endpoints");
+    } catch (e) {
+      document.getElementById("main").innerHTML =
+        `<div class="empty" style="margin-top:40px"><strong>Backend unreachable</strong>${esc(e.message)}</div>`;
+      return;
+    }
+    const hw = document.getElementById("hwReadout");
+    hw.textContent = state.meta.hardware_string || "unknown hardware";
+    hw.title = state.meta.hardware_string;
+    document.getElementById("mlxBadge").innerHTML = state.meta.mlx_available
+      ? `<span class="on">● MLX available</span>`
+      : `<span class="off">○ MLX off — no Apple Silicon</span>`;
+    render();
+  }
+
+  boot();
+})();

--- a/webui_static/charts.js
+++ b/webui_static/charts.js
@@ -1,0 +1,293 @@
+/* Minimal SVG chart library for Context Bench.
+   Line charts over context size (log2 x-axis) or batch size, with a
+   crosshair tooltip, surface-ringed markers and an HTML legend. */
+
+(function () {
+  "use strict";
+
+  const SVG_NS = "http://www.w3.org/2000/svg";
+
+  function el(name, attrs, parent) {
+    const node = document.createElementNS(SVG_NS, name);
+    for (const key in attrs) node.setAttribute(key, attrs[key]);
+    if (parent) parent.appendChild(node);
+    return node;
+  }
+
+  function fmtNum(value, opts) {
+    if (value == null || !isFinite(value)) return "–";
+    if (value === 0) return "0";
+    const abs = Math.abs(value);
+    if (opts && opts.seconds) {
+      if (abs < 0.995) return (value * 1000).toFixed(0) + " ms";
+      if (abs < 10) return value.toFixed(2) + " s";
+      return value.toFixed(1) + " s";
+    }
+    if (abs >= 1e6) return (value / 1e6).toFixed(1) + "M";
+    if (abs >= 1e4) return (value / 1e3).toFixed(1) + "K";
+    if (abs >= 100) return value.toFixed(0);
+    if (abs >= 10) return value.toFixed(1);
+    if (abs >= 1) return value.toFixed(2);
+    return value.toFixed(3);
+  }
+
+  function trimZeros(s) {
+    return s.indexOf(".") >= 0 ? s.replace(/\.?0+$/, "") : s;
+  }
+
+  function fmtTick(t) {
+    if (t === 0) return "0";
+    const abs = Math.abs(t);
+    if (abs >= 1e6) return trimZeros((t / 1e6).toFixed(1)) + "M";
+    if (abs >= 1e4) return trimZeros((t / 1e3).toFixed(1)) + "K";
+    const s = abs >= 100 ? t.toFixed(0) : abs >= 10 ? t.toFixed(1) : abs >= 1 ? t.toFixed(2) : t.toFixed(3);
+    return trimZeros(s);
+  }
+
+  function niceTicks(min, max, count) {
+    if (!(max > min)) max = min + 1;
+    const span = max - min;
+    const step0 = span / Math.max(1, count);
+    const mag = Math.pow(10, Math.floor(Math.log10(step0)));
+    let step = mag;
+    for (const m of [1, 2, 2.5, 5, 10]) {
+      if (step0 <= m * mag) { step = m * mag; break; }
+    }
+    const ticks = [];
+    const start = Math.ceil(min / step) * step;
+    for (let v = start; v <= max + step * 1e-9; v += step) ticks.push(Math.round(v * 1e9) / 1e9);
+    return ticks;
+  }
+
+  function ctxLabel(v) {
+    return (v >= 1 ? (Number.isInteger(v) ? v : v) : v) + "k";
+  }
+
+  // ---------------------------------------------------------------
+  // Line chart
+  // opts: { series: [{name, color, points: [[x, y], ...]}],
+  //         logX, xLabel, yLabel, height, seconds, xTickFormat }
+  // ---------------------------------------------------------------
+  function lineChart(container, opts) {
+    container.classList.add("viz");
+    container.innerHTML = "";
+    const series = (opts.series || []).map(s => ({
+      ...s,
+      points: (s.points || [])
+        .filter(p => p[1] != null && isFinite(p[1]))
+        .slice()
+        .sort((a, b) => a[0] - b[0]),
+    })).filter(s => s.points.length);
+
+    if (!series.length) {
+      const empty = document.createElement("div");
+      empty.className = "chart-empty";
+      empty.textContent = "No data for this metric.";
+      container.appendChild(empty);
+      return { destroy() {} };
+    }
+
+    const width = Math.max(320, opts.width || container.clientWidth || 720);
+    const margin = { top: 14, right: 16, bottom: 40, left: 56 };
+
+    // optional in-SVG title & legend (used for standalone PNG export);
+    // tokens resolve against the container so a .force-light wrapper works
+    const tokens = getComputedStyle(container);
+    const tok = name => tokens.getPropertyValue(name).trim();
+    if (opts.svgTitle) margin.top += 30;
+    let legendRows = [];
+    if (opts.svgLegend && series.length >= 2) {
+      const iw0 = width - margin.left - margin.right;
+      let row = [], used = 0;
+      for (const s of series) {
+        const w = 30 + s.name.length * 6.8;
+        if (used + w > iw0 && row.length) { legendRows.push(row); row = []; used = 0; }
+        row.push({ s, x: used });
+        used += w;
+      }
+      if (row.length) legendRows.push(row);
+    }
+    const legendHeight = legendRows.length ? legendRows.length * 20 + 10 : 0;
+    const height = (opts.height || 300) + (opts.svgTitle ? 30 : 0) + legendHeight;
+
+    const xt = v => (opts.logX ? Math.log2(v) : v);
+    const xsAll = [...new Set(series.flatMap(s => s.points.map(p => p[0])))].sort((a, b) => a - b);
+    const xMin = xt(xsAll[0]);
+    const xMax = xt(xsAll[xsAll.length - 1]);
+    const ysAll = series.flatMap(s => s.points.map(p => p[1]));
+    let yMin = 0;
+    let yMax = Math.max(...ysAll);
+    if (yMax <= 0) yMax = 1;
+    yMax *= 1.06;
+
+    const iw = width - margin.left - margin.right;
+    const ih = height - margin.top - margin.bottom - legendHeight;
+    const px = v => margin.left + (xMax === xMin ? iw / 2 : ((xt(v) - xMin) / (xMax - xMin)) * iw);
+    const py = v => margin.top + ih - ((v - yMin) / (yMax - yMin)) * ih;
+
+    const svg = el("svg", { viewBox: `0 0 ${width} ${height}`, width, height, role: "img" }, null);
+    container.appendChild(svg);
+
+    if (opts.svgTitle) {
+      const t = el("text", {
+        x: margin.left, y: 22, fill: tok("--ink") || "#111",
+        "font-family": "system-ui, sans-serif", "font-size": 13.5, "font-weight": 600,
+      }, svg);
+      t.textContent = opts.svgTitle;
+    }
+    for (let r = 0; r < legendRows.length; r++) {
+      const y = height - legendHeight + 14 + r * 20;
+      for (const item of legendRows[r]) {
+        const x = margin.left + item.x;
+        el("line", { x1: x, x2: x + 14, y1: y - 4, y2: y - 4, stroke: item.s.color, "stroke-width": 3 }, svg);
+        const t = el("text", {
+          x: x + 20, y, fill: tok("--ink-2") || "#555",
+          "font-family": "system-ui, sans-serif", "font-size": 11,
+        }, svg);
+        t.textContent = item.s.name;
+      }
+    }
+
+    // gridlines + y ticks — one consistent unit per axis
+    const msMode = !!opts.seconds && yMax < 0.995;
+    let yTitle = opts.yLabel || "";
+    if (msMode && yTitle === "s") yTitle = "ms";
+    const yTicks = niceTicks(yMin, msMode ? yMax * 1000 : yMax, 5).map(t => (msMode ? t / 1000 : t));
+    for (const tick of yTicks) {
+      const y = py(tick);
+      el("line", { x1: margin.left, x2: width - margin.right, y1: y, y2: y, class: "gridline" }, svg);
+      const label = el("text", { x: margin.left - 8, y: y + 3.5, "text-anchor": "end", class: "tick-label" }, svg);
+      label.textContent = fmtTick(msMode ? tick * 1000 : tick);
+    }
+    // baseline + x ticks at data positions
+    el("line", {
+      x1: margin.left, x2: width - margin.right,
+      y1: margin.top + ih, y2: margin.top + ih, class: "axisline",
+    }, svg);
+    const maxXTicks = Math.floor(iw / 46);
+    const tickEvery = Math.max(1, Math.ceil(xsAll.length / Math.max(2, maxXTicks)));
+    xsAll.forEach((v, i) => {
+      if (i % tickEvery !== 0 && i !== xsAll.length - 1) return;
+      const x = px(v);
+      el("line", { x1: x, x2: x, y1: margin.top + ih, y2: margin.top + ih + 4, class: "axisline" }, svg);
+      const label = el("text", { x, y: margin.top + ih + 16, "text-anchor": "middle", class: "tick-label" }, svg);
+      label.textContent = opts.xTickFormat ? opts.xTickFormat(v) : ctxLabel(v);
+    });
+    if (opts.xLabel) {
+      const t = el("text", { x: margin.left + iw / 2, y: margin.top + ih + 34, "text-anchor": "middle", class: "axis-title" }, svg);
+      t.textContent = opts.xLabel;
+    }
+    if (yTitle) {
+      const t = el("text", {
+        x: 12, y: margin.top + ih / 2, class: "axis-title",
+        transform: `rotate(-90 12 ${margin.top + ih / 2})`, "text-anchor": "middle",
+      }, svg);
+      t.textContent = yTitle;
+    }
+
+    // series — dots carry their values as data attributes so exported
+    // (standalone) SVGs can offer point tooltips without re-plumbing data
+    for (const s of series) {
+      const d = s.points.map((p, i) => `${i ? "L" : "M"}${px(p[0]).toFixed(1)},${py(p[1]).toFixed(1)}`).join("");
+      el("path", { d, class: "series-line", stroke: s.color }, svg);
+      for (const p of s.points) {
+        el("circle", {
+          cx: px(p[0]), cy: py(p[1]), r: 4, fill: s.color, class: "series-dot",
+          "data-s": s.name,
+          "data-x": opts.xTickFormat ? opts.xTickFormat(p[0]) : ctxLabel(p[0]),
+          "data-v": fmtNum(p[1], opts),
+        }, svg);
+      }
+    }
+
+    // crosshair + tooltip
+    const crosshair = el("line", {
+      y1: margin.top, y2: margin.top + ih, x1: 0, x2: 0,
+      class: "crosshair", visibility: "hidden",
+    }, svg);
+    const tooltip = document.createElement("div");
+    tooltip.className = "viz-tooltip";
+    tooltip.hidden = true;
+    container.appendChild(tooltip);
+
+    function onMove(event) {
+      const rect = svg.getBoundingClientRect();
+      const mx = ((event.clientX - rect.left) / rect.width) * width;
+      if (mx < margin.left - 10 || mx > width - margin.right + 10) { onLeave(); return; }
+      let best = xsAll[0];
+      let bestDist = Infinity;
+      for (const v of xsAll) {
+        const dist = Math.abs(px(v) - mx);
+        if (dist < bestDist) { bestDist = dist; best = v; }
+      }
+      const x = px(best);
+      crosshair.setAttribute("x1", x);
+      crosshair.setAttribute("x2", x);
+      crosshair.setAttribute("visibility", "visible");
+
+      const rows = series
+        .map(s => {
+          const p = s.points.find(pt => pt[0] === best);
+          return p ? { name: s.name, color: s.color, value: p[1] } : null;
+        })
+        .filter(Boolean)
+        .sort((a, b) => b.value - a.value);
+      tooltip.innerHTML =
+        `<div class="tt-title">${opts.xTickFormat ? opts.xTickFormat(best) : ctxLabel(best)}</div>` +
+        rows.map(r =>
+          `<div class="tt-row"><span class="tt-swatch" style="background:${r.color}"></span>` +
+          `<span class="tt-name">${escapeHtml(r.name)}</span>` +
+          `<span class="tt-val">${fmtNum(r.value, opts)}</span></div>`).join("");
+      tooltip.hidden = false;
+      const cw = container.clientWidth;
+      const ttw = tooltip.offsetWidth;
+      const left = (x / width) * rect.width;
+      tooltip.style.left = Math.min(Math.max(4, left + 14), cw - ttw - 4) + "px";
+      tooltip.style.top = "8px";
+    }
+    function onLeave() {
+      crosshair.setAttribute("visibility", "hidden");
+      tooltip.hidden = true;
+    }
+    svg.addEventListener("mousemove", onMove);
+    svg.addEventListener("mouseleave", onLeave);
+
+    // legend (only for >= 2 series)
+    if (series.length >= 2 && opts.legend !== false) {
+      const legend = document.createElement("div");
+      legend.className = "legend";
+      for (const s of series) {
+        const item = document.createElement("div");
+        item.className = "legend-item";
+        item.innerHTML = `<span class="legend-swatch" style="background:${s.color}"></span>${escapeHtml(s.name)}`;
+        legend.appendChild(item);
+      }
+      container.appendChild(legend);
+    }
+    return { destroy() { container.innerHTML = ""; } };
+  }
+
+  function sparkline(points, width, height, color) {
+    width = width || 110;
+    height = height || 26;
+    const pts = (points || []).filter(p => p[1] != null && isFinite(p[1]));
+    if (pts.length < 2) return "";
+    const xs = pts.map(p => Math.log2(p[0]));
+    const ys = pts.map(p => p[1]);
+    const xMin = Math.min(...xs), xMax = Math.max(...xs);
+    const yMin = 0, yMax = Math.max(...ys) || 1;
+    const px = v => 2 + ((v - xMin) / (xMax - xMin || 1)) * (width - 4);
+    const py = v => height - 2 - ((v - yMin) / (yMax - yMin || 1)) * (height - 4);
+    const d = pts.map((p, i) => `${i ? "L" : "M"}${px(Math.log2(p[0])).toFixed(1)},${py(p[1]).toFixed(1)}`).join("");
+    return `<svg class="spark" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" aria-hidden="true">` +
+      `<path d="${d}"${color ? ` style="stroke:${color}"` : ""}></path></svg>`;
+  }
+
+  function escapeHtml(text) {
+    return String(text).replace(/[&<>"']/g, c => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    }[c]));
+  }
+
+  window.Charts = { lineChart, sparkline, fmtNum, escapeHtml };
+})();

--- a/webui_static/core.js
+++ b/webui_static/core.js
@@ -1,0 +1,326 @@
+/* Context Bench core: shared state, API/UI helpers, router, modal, theme.
+   Everything is exposed on window.CB; view modules register themselves in
+   CB.views and are dispatched by CB.render(). Load order:
+   charts.js → export.js → core.js → report.js → view-*.js → app.js */
+
+(function () {
+  "use strict";
+
+  const esc = Charts.escapeHtml;
+  const fmt = Charts.fmtNum;
+
+  const state = {
+    meta: null,
+    endpoints: [],
+    results: [],
+    details: {},           // folder -> full detail payload
+    runsPollTimer: null,
+    runLogs: {},           // run id -> { offset, text, notified }
+    compare: {
+      slots: new Map(),    // folder -> color slot index (0..7)
+      metric: "generation_tps",
+      grid: false,
+    },
+    resultsFilter: "",
+    runFormEngine: null,
+    runFormEndpoint: "",
+    runModelPicker: null,
+  };
+
+  const METRICS = [
+    { key: "generation_tps", label: "Generation", unit: "tok/s" },
+    { key: "prompt_tps", label: "Prompt", unit: "tok/s" },
+    { key: "time_to_first_token", label: "TTFT", unit: "s", seconds: true },
+    { key: "time_per_output_token", label: "TPOT", unit: "s", seconds: true },
+    { key: "total_time", label: "Total time", unit: "s", seconds: true },
+    { key: "generation_utf8_bytes_per_sec", label: "Gen bytes/s", unit: "B/s" },
+    { key: "prompt_utf8_bytes_per_sec", label: "Prompt bytes/s", unit: "B/s" },
+    { key: "peak_memory_gb", label: "Peak memory", unit: "GB" },
+    { key: "host_memory_gb", label: "Host RAM", unit: "GB" },
+    { key: "kv_cache_gb", label: "KV cache", unit: "GB" },
+    { key: "kv_cache_usage_perc", label: "KV usage", unit: "%" },
+  ];
+
+  function metricsForKeys(keys) {
+    return METRICS.filter(m => keys.has(m.key));
+  }
+
+  // ----------------------------------------------------------------- utils
+
+  async function api(path, opts) {
+    const res = await fetch(path, opts && opts.body ? {
+      method: opts.method || "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(opts.body),
+    } : opts);
+    if (!res.ok) {
+      let detail = res.statusText;
+      try { detail = (await res.json()).detail || detail; } catch (e) { /* ignore */ }
+      throw new Error(detail);
+    }
+    return res.json();
+  }
+
+  function toast(message, isError) {
+    const stack = document.getElementById("toastStack");
+    const node = document.createElement("div");
+    node.className = "toast" + (isError ? " err" : "");
+    node.textContent = message;
+    stack.appendChild(node);
+    setTimeout(() => node.remove(), isError ? 7000 : 3500);
+  }
+
+  function seriesColor(slot) {
+    const styles = getComputedStyle(document.documentElement);
+    return styles.getPropertyValue(`--s${(slot % 8) + 1}`).trim();
+  }
+
+  function ctxNum(ctx) {
+    const v = parseFloat(String(ctx).replace(/k$/i, ""));
+    return isFinite(v) ? v : 0;
+  }
+
+  function fmtDate(iso) {
+    if (!iso) return "–";
+    return iso.replace("T", " ").slice(0, 16);
+  }
+
+  function fmtDuration(seconds) {
+    if (seconds == null) return "–";
+    const s = Math.floor(seconds);
+    if (s < 60) return s + "s";
+    if (s < 3600) return Math.floor(s / 60) + "m " + (s % 60) + "s";
+    return Math.floor(s / 3600) + "h " + Math.floor((s % 3600) / 60) + "m";
+  }
+
+  function pageHead(eyebrow, title, sub, actionsHtml) {
+    return `<div class="page-head">
+      <div>
+        <div class="eyebrow">${esc(eyebrow)}</div>
+        <h1 class="page-title">${esc(title)}</h1>
+        ${sub ? `<div class="page-sub">${sub}</div>` : ""}
+      </div>
+      ${actionsHtml || ""}
+    </div>`;
+  }
+
+  function resultName(summary) {
+    if (summary.label) return summary.label;
+    return `${summary.engine}: ${summary.model}`;
+  }
+
+  // chart/series label: always carries the model so runs against the same
+  // endpoint stay distinguishable in legends, tooltips and exports
+  function seriesLabel(summary) {
+    if (!summary.label) return `${summary.engine}: ${summary.model}`;
+    const labelHasModel = summary.model &&
+      summary.label.toLowerCase().includes(String(summary.model).toLowerCase());
+    return labelHasModel ? summary.label : `${summary.label} · ${summary.model}`;
+  }
+
+  function resultSubtitle(summary) {
+    const parts = [`${summary.engine} · ${summary.model}`];
+    if (summary.machine) parts.push(summary.machine);
+    return parts.join(" · ");
+  }
+
+  function matchesFilter(summary, filter) {
+    if (!filter) return true;
+    const haystack = [summary.folder, summary.engine, summary.model, summary.label,
+      summary.machine, summary.endpoint].join(" ").toLowerCase();
+    return filter.toLowerCase().split(/\s+/).every(term => haystack.includes(term));
+  }
+
+  function engineById(id) {
+    return state.meta.engines.find(e => e.id === id);
+  }
+
+  // human-readable connection target of an endpoint ("" for local engines)
+  function endpointTarget(ep) {
+    if (ep.base_url) return ep.base_url;
+    if (ep.host) return ep.host + (ep.port ? ":" + ep.port : "");
+    return "";
+  }
+
+  // ------------------------------------------------------------- data cache
+
+  async function ensureResults(force) {
+    if (!force && state.results.length) return state.results;
+    state.results = await api("/api/results");
+    return state.results;
+  }
+
+  async function ensureDetail(folder) {
+    if (state.details[folder]) return state.details[folder];
+    state.details[folder] = await api(`/api/results/${encodeURIComponent(folder)}`);
+    return state.details[folder];
+  }
+
+  // stable color slots for the comparison selection
+  function toggleCompare(folder, on) {
+    const slots = state.compare.slots;
+    if (on) {
+      if (slots.has(folder)) return true;
+      if (slots.size >= 8) {
+        toast("Comparison is limited to 8 runs — the palette stays readable that way.", true);
+        return false;
+      }
+      const used = new Set(slots.values());
+      let slot = 0;
+      while (used.has(slot)) slot++;
+      slots.set(folder, slot);
+    } else {
+      slots.delete(folder);
+    }
+    return true;
+  }
+
+  // ----------------------------------------------------------------- modal
+
+  function openModal(html, opts) {
+    const backdrop = document.getElementById("modalBackdrop");
+    const modal = document.getElementById("modal");
+    modal.className = "modal" + (opts && opts.narrow ? " narrow" : "");
+    modal.innerHTML = html;
+    backdrop.hidden = false;
+    modal.querySelectorAll("[data-close]").forEach(b => b.addEventListener("click", closeModal));
+    return modal;
+  }
+  function closeModal() {
+    document.getElementById("modalBackdrop").hidden = true;
+    document.getElementById("modal").innerHTML = "";
+  }
+  document.getElementById("modalBackdrop").addEventListener("click", e => {
+    if (e.target.id === "modalBackdrop") closeModal();
+  });
+  document.addEventListener("keydown", e => { if (e.key === "Escape") closeModal(); });
+
+  // ----------------------------------------------------------------- theme
+
+  function initTheme() {
+    const saved = localStorage.getItem("cb-theme");
+    const theme = saved || (matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
+    applyTheme(theme);
+    document.getElementById("themeToggle").addEventListener("click", () => {
+      const next = document.documentElement.dataset.theme === "light" ? "dark" : "light";
+      localStorage.setItem("cb-theme", next);
+      applyTheme(next);
+      render();
+    });
+  }
+  function applyTheme(theme) {
+    if (theme === "light") document.documentElement.dataset.theme = "light";
+    else delete document.documentElement.dataset.theme;
+  }
+
+  // ----------------------------------------------------------------- router
+
+  const VIEW_NAMES = ["run", "results", "compare", "endpoints", "tools"];
+  const views = {};   // name -> render function, registered by the view modules
+
+  function currentView() {
+    const hash = location.hash.replace("#", "");
+    return VIEW_NAMES.includes(hash) ? hash : "run";
+  }
+
+  function render() {
+    const view = currentView();
+    document.querySelectorAll("#nav a").forEach(a =>
+      a.classList.toggle("active", a.dataset.view === view));
+    for (const name of VIEW_NAMES) {
+      document.getElementById("view-" + name).hidden = name !== view;
+    }
+    if (views[view]) views[view]();
+  }
+  window.addEventListener("hashchange", render);
+
+  // charts pick up their width at render time — re-render on resize
+  let resizeTimer = null;
+  window.addEventListener("resize", () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      if (currentView() === "compare" && CB.onCompareResize) CB.onCompareResize();
+    }, 250);
+  });
+
+  // ------------------------------------------------------------ model picker
+  // A text input that upgrades to a dropdown once the target server's
+  // model list was fetched (OpenAI /v1/models or the local Ollama daemon).
+
+  function attachModelPicker({ select, input, button, hint, getConnection }) {
+    function show(asSelect) {
+      select.hidden = !asSelect;
+      input.hidden = asSelect;
+    }
+    async function load(auto) {
+      const connection = getConnection();
+      if (!connection) {
+        show(false);
+        if (!auto) toast("No connection configured — enter the model manually.", true);
+        return;
+      }
+      button.disabled = true;
+      const original = button.textContent;
+      button.textContent = "…";
+      try {
+        const res = await api("/api/models", { body: connection });
+        if (res.models && res.models.length) {
+          const current = (select.hidden ? input.value : select.value).trim();
+          const models = res.models.slice();
+          if (current && current !== "__custom__" && !models.includes(current)) models.unshift(current);
+          select.innerHTML = models.map(m =>
+            `<option value="${esc(m)}" ${m === current ? "selected" : ""}>${esc(m)}</option>`).join("") +
+            `<option value="__custom__">✎ enter manually…</option>`;
+          show(true);
+          if (hint) hint.textContent = `${res.models.length} model${res.models.length === 1 ? "" : "s"} found on the server.`;
+        } else {
+          show(false);
+          if (hint) hint.textContent = "No model list from the server — enter manually.";
+          if (!auto && res.detail) toast("Model discovery failed: " + res.detail, true);
+        }
+      } catch (e) {
+        show(false);
+        if (hint) hint.textContent = "Model discovery failed — enter manually.";
+      } finally {
+        button.disabled = false;
+        button.textContent = original;
+      }
+    }
+    select.addEventListener("change", () => {
+      if (select.value === "__custom__") {
+        input.value = "";
+        show(false);
+        input.focus();
+      }
+    });
+    button.addEventListener("click", () => load(false));
+    return {
+      load,
+      value: () => (select.hidden ? input.value : select.value === "__custom__" ? "" : select.value).trim(),
+      set: value => {
+        if (!select.hidden && [...select.options].some(o => o.value === value)) select.value = value;
+        else { input.value = value; show(false); }
+      },
+    };
+  }
+
+  function modelPickerHtml(idPrefix, currentValue, placeholder) {
+    return `<div class="model-row">
+      <select id="${idPrefix}Sel" hidden></select>
+      <input type="text" id="${idPrefix}" value="${esc(currentValue || "")}" placeholder="${esc(placeholder || "")}">
+      <button type="button" class="btn small" id="${idPrefix}Load" title="Load model list from the server">↻</button>
+    </div>`;
+  }
+
+  window.CB = {
+    state, METRICS, metricsForKeys,
+    esc, fmt, api, toast,
+    seriesColor, ctxNum, fmtDate, fmtDuration,
+    pageHead, resultName, resultSubtitle, seriesLabel, matchesFilter, engineById, endpointTarget,
+    ensureResults, ensureDetail, toggleCompare,
+    openModal, closeModal, initTheme,
+    views, currentView, render,
+    attachModelPicker, modelPickerHtml,
+    onCompareResize: null,
+  };
+})();

--- a/webui_static/export.js
+++ b/webui_static/export.js
@@ -1,0 +1,704 @@
+/* Export machinery: charts as PNG/JPEG, results as CSV / plain text,
+   self-contained HTML report, hand-rolled PDF report, ZIP bundling.
+   All client-side, no dependencies. */
+
+(function () {
+  "use strict";
+
+  // ------------------------------------------------------------- ZIP (store)
+
+  const CRC_TABLE = (() => {
+    const table = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+      let c = n;
+      for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      table[n] = c >>> 0;
+    }
+    return table;
+  })();
+
+  function crc32(bytes) {
+    let crc = 0xffffffff;
+    for (let i = 0; i < bytes.length; i++) crc = CRC_TABLE[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8);
+    return (crc ^ 0xffffffff) >>> 0;
+  }
+
+  function makeZip(files) {
+    const encoder = new TextEncoder();
+    const chunks = [];
+    const central = [];
+    let offset = 0;
+    const now = new Date();
+    const time = (now.getHours() << 11) | (now.getMinutes() << 5) | (now.getSeconds() >> 1);
+    const day = ((now.getFullYear() - 1980) << 9) | ((now.getMonth() + 1) << 5) | now.getDate();
+
+    for (const file of files) {
+      const nameBytes = encoder.encode(file.name);
+      const crc = crc32(file.data);
+      const size = file.data.length;
+      const local = new DataView(new ArrayBuffer(30));
+      local.setUint32(0, 0x04034b50, true);
+      local.setUint16(4, 20, true);
+      local.setUint16(6, 0x0800, true);
+      local.setUint16(8, 0, true);
+      local.setUint16(10, time, true);
+      local.setUint16(12, day, true);
+      local.setUint32(14, crc, true);
+      local.setUint32(18, size, true);
+      local.setUint32(22, size, true);
+      local.setUint16(26, nameBytes.length, true);
+      local.setUint16(28, 0, true);
+      chunks.push(new Uint8Array(local.buffer), nameBytes, file.data);
+
+      const cd = new DataView(new ArrayBuffer(46));
+      cd.setUint32(0, 0x02014b50, true);
+      cd.setUint16(4, 20, true);
+      cd.setUint16(6, 20, true);
+      cd.setUint16(8, 0x0800, true);
+      cd.setUint16(10, 0, true);
+      cd.setUint16(12, time, true);
+      cd.setUint16(14, day, true);
+      cd.setUint32(16, crc, true);
+      cd.setUint32(20, size, true);
+      cd.setUint32(24, size, true);
+      cd.setUint16(28, nameBytes.length, true);
+      cd.setUint32(42, offset, true);
+      central.push(new Uint8Array(cd.buffer), nameBytes);
+      offset += 30 + nameBytes.length + size;
+    }
+
+    let cdSize = 0;
+    for (const c of central) cdSize += c.length;
+    const end = new DataView(new ArrayBuffer(22));
+    end.setUint32(0, 0x06054b50, true);
+    end.setUint16(8, files.length, true);
+    end.setUint16(10, files.length, true);
+    end.setUint32(12, cdSize, true);
+    end.setUint32(16, offset, true);
+    return new Blob([...chunks, ...central, new Uint8Array(end.buffer)], { type: "application/zip" });
+  }
+
+  // --------------------------------------------------------- SVG -> canvas
+
+  const INLINE_PROPS = ["fill", "stroke", "stroke-width", "stroke-linecap", "stroke-linejoin",
+    "opacity", "font-family", "font-size", "font-weight", "letter-spacing", "visibility"];
+
+  async function svgToCanvas(svgEl, scale, background) {
+    const clone = svgEl.cloneNode(true);
+    const walk = (orig, copy) => {
+      if (orig.nodeType !== 1) return;
+      const computed = getComputedStyle(orig);
+      let style = "";
+      for (const prop of INLINE_PROPS) {
+        const value = computed.getPropertyValue(prop);
+        if (value) style += `${prop}:${value};`;
+      }
+      copy.setAttribute("style", style);
+      for (let i = 0; i < orig.children.length; i++) walk(orig.children[i], copy.children[i]);
+    };
+    walk(svgEl, clone);
+
+    const width = parseFloat(svgEl.getAttribute("width"));
+    const height = parseFloat(svgEl.getAttribute("height"));
+    clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    const xml = new XMLSerializer().serializeToString(clone);
+    const url = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(xml);
+
+    const img = new Image();
+    await new Promise((resolve, reject) => {
+      img.onload = resolve;
+      img.onerror = () => reject(new Error("SVG rasterization failed"));
+      img.src = url;
+    });
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.round(width * scale);
+    canvas.height = Math.round(height * scale);
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = background;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    return canvas;
+  }
+
+  async function canvasToPngBytes(canvas) {
+    const blob = await new Promise(resolve => canvas.toBlob(resolve, "image/png"));
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+
+  async function canvasToJpeg(canvas) {
+    const blob = await new Promise(resolve => canvas.toBlob(resolve, "image/jpeg", 0.92));
+    return { bytes: new Uint8Array(await blob.arrayBuffer()), width: canvas.width, height: canvas.height };
+  }
+
+  // --------------------------------------------------------- text builders
+
+  function csvEscape(value) {
+    const s = value == null ? "" : String(value);
+    return /[",\n;]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  }
+
+  function buildResultsCsv(entries) {
+    const metaCols = ["run", "engine", "model", "machine", "folder"];
+    const dataCols = [];
+    for (const e of entries) {
+      for (const row of e.detail.results) {
+        for (const key of Object.keys(row)) {
+          if (key !== "generated_text" && key !== "reasoning_text" && !dataCols.includes(key)) dataCols.push(key);
+        }
+      }
+    }
+    const lines = [metaCols.concat(dataCols).join(",")];
+    for (const e of entries) {
+      const s = e.detail.summary;
+      for (const row of e.detail.results) {
+        lines.push(metaCols.map(c => csvEscape({
+          run: e.name, engine: s.engine, model: s.model, machine: s.machine, folder: s.folder,
+        }[c])).concat(dataCols.map(c => csvEscape(row[c]))).join(","));
+      }
+    }
+    return lines.join("\n") + "\n";
+  }
+
+  function buildBatchCsv(entries) {
+    const withBatch = entries.filter(e => e.detail.batch_data && e.detail.batch_data.length);
+    if (!withBatch.length) return null;
+    const dataCols = [];
+    for (const e of withBatch) {
+      for (const row of e.detail.batch_data) {
+        for (const key of Object.keys(row)) if (!dataCols.includes(key)) dataCols.push(key);
+      }
+    }
+    const lines = [["run", "engine", "model"].concat(dataCols).join(",")];
+    for (const e of withBatch) {
+      const s = e.detail.summary;
+      for (const row of e.detail.batch_data) {
+        lines.push([csvEscape(e.name), csvEscape(s.engine), csvEscape(s.model)]
+          .concat(dataCols.map(c => csvEscape(row[c]))).join(","));
+      }
+    }
+    return lines.join("\n") + "\n";
+  }
+
+  function pad(value, width) {
+    const s = value == null ? "–" : String(value);
+    return s.length >= width ? s : s + " ".repeat(width - s.length);
+  }
+
+  // shared tabular model for TXT / HTML / PDF: one table per metric
+  function buildTables(entries, metrics, fmt) {
+    const contexts = [...new Set(entries.flatMap(e => e.detail.results.map(r => r.context_size)))]
+      .sort((a, b) => parseFloat(a) - parseFloat(b));
+    const tables = [];
+    for (const metric of metrics) {
+      const rows = contexts.map(ctx => [ctx].concat(entries.map(e => {
+        const row = e.detail.results.find(r => r.context_size === ctx);
+        return row && row[metric.key] != null && isFinite(row[metric.key])
+          ? fmt(row[metric.key], { seconds: metric.seconds }) : null;
+      })));
+      if (!rows.some(r => r.slice(1).some(v => v != null))) continue;
+      tables.push({
+        title: `${metric.label} [${metric.unit}]`,
+        headers: ["context"].concat(entries.map(e => e.name)),
+        rows,
+      });
+    }
+    const withBatch = entries.filter(e => e.detail.batch_data && e.detail.batch_data.length);
+    if (withBatch.length) {
+      const batchSizes = [...new Set(withBatch.flatMap(e => e.detail.batch_data.map(b => b.batch_size)))]
+        .sort((a, b) => a - b);
+      const hasDecode = withBatch.some(e => e.detail.batch_data.some(b => b.decode_tps_total != null));
+      tables.push({
+        title: `Batch sweep [prompt / e2e-gen${hasDecode ? " / decode" : ""} tok/s, N parallel clients]`,
+        headers: ["batch"].concat(withBatch.map(e => e.name)),
+        rows: batchSizes.map(bs => [bs].concat(withBatch.map(e => {
+          const row = e.detail.batch_data.find(b => b.batch_size === bs);
+          if (!row) return null;
+          const cell = `${fmt(row.prompt_tps)} / ${fmt(row.generation_tps)}`;
+          return row.decode_tps_total != null ? `${cell} / ${fmt(row.decode_tps_total)}` : cell;
+        }))),
+      });
+    }
+    return tables;
+  }
+
+  function buildComparisonTxt(entries, tables, title) {
+    const lines = [];
+    lines.push((title || "CONTEXT BENCH — COMPARISON EXPORT").toUpperCase());
+    lines.push("Generated: " + new Date().toISOString().slice(0, 19).replace("T", " "));
+    lines.push("");
+    lines.push("Runs:");
+    entries.forEach((e, i) => {
+      const s = e.detail.summary;
+      lines.push(`  [${i + 1}] ${e.name}`);
+      lines.push(`      ${s.engine} · ${s.model}${s.machine ? " · " + s.machine : ""}`);
+      if (s.hardware) lines.push(`      ${s.hardware}`);
+      lines.push(`      ${s.folder}`);
+    });
+    lines.push("");
+    for (const table of tables) {
+      lines.push(`== ${table.title} ==`);
+      const widths = table.headers.map((h, i) =>
+        Math.max(h.length, ...table.rows.map(r => (r[i] == null ? 1 : String(r[i]).length))) + 2);
+      lines.push(table.headers.map((h, i) => pad(h, widths[i])).join(""));
+      for (const row of table.rows) lines.push(row.map((v, i) => pad(v, widths[i])).join(""));
+      lines.push("");
+    }
+    return lines.join("\n");
+  }
+
+  // --------------------------------------------------------- HTML report
+
+  const htmlEscape = Charts.escapeHtml;
+
+  // Self-contained HTML report with a dark/light toggle (dark is default).
+  // charts: [{title, svg}] — raw class-based SVG markup, themed by the
+  // report CSS; dots are interactive (hover/click shows the value).
+  function buildHtmlReport(title, entries, tables, charts, legend) {
+    const h = htmlEscape;
+    const generated = new Date().toISOString().slice(0, 19).replace("T", " ");
+    const runsHtml = entries.map((e, i) => {
+      const s = e.detail.summary;
+      return `<tr><td class="idx">${i + 1}</td><td><strong>${h(e.name)}</strong></td>
+        <td>${h(s.engine)}</td><td class="mono">${h(s.model)}</td>
+        <td>${h(s.machine || "–")}</td><td class="mono small">${h(s.folder)}</td></tr>`;
+    }).join("");
+    const legendHtml = (legend || []).length < 2 ? "" :
+      `<div class="legend">${legend.map(l =>
+        `<span class="legend-item"><span class="legend-swatch" style="background:${l.color}"></span>${h(l.name)}</span>`).join("")}</div>`;
+    const chartsHtml = charts.map(c => `<figure>
+      <figcaption>${h(c.title)}</figcaption>
+      <div class="viz">${c.svg}</div>
+      ${legendHtml}
+    </figure>`).join("\n");
+    const tablesHtml = tables.map(t => `
+      <h2>${h(t.title)}</h2>
+      <table><thead><tr>${t.headers.map((x, i) =>
+        `<th${i ? "" : ' class="left"'}>${h(x)}</th>`).join("")}</tr></thead>
+      <tbody>${t.rows.map(r => `<tr>${r.map((v, i) =>
+        `<td${i ? "" : ' class="left mono"'}>${v == null ? "–" : h(v)}</td>`).join("")}</tr>`).join("")}</tbody>
+      </table>`).join("\n");
+
+    return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${h(title)}</title>
+<style>
+  :root {
+    color-scheme: dark;
+    --page: #0c0c0b; --surface: #1a1a19; --raised: #232322;
+    --ink: #f4f3ee; --ink-2: #c3c2b7; --muted: #8b897f;
+    --hairline: #2c2c2a; --stripe: #1f1f1e; --head: #161615;
+    --grid: #262624; --axis: #383835;
+  }
+  :root[data-theme="light"] {
+    color-scheme: light;
+    --page: #f4f3ee; --surface: #fcfcfb; --raised: #f4f3ee;
+    --ink: #171614; --ink-2: #52514e; --muted: #8b897f;
+    --hairline: #e0dfd7; --stripe: #faf9f6; --head: #f9f8f4;
+    --grid: #e5e4dc; --axis: #c6c5bb;
+  }
+  body { margin: 0; background: var(--page); color: var(--ink);
+    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif; }
+  .wrap { max-width: 1060px; margin: 0 auto; padding: 40px 28px 80px; }
+  header { border-bottom: 2px solid var(--ink); padding-bottom: 18px; margin-bottom: 26px;
+    position: relative; }
+  .eyebrow { font: 600 10px/1 ui-monospace, Menlo, monospace; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--muted); margin-bottom: 10px; }
+  h1 { font-size: 26px; margin: 0 0 6px; letter-spacing: -0.02em; }
+  .meta { color: var(--ink-2); font-size: 12.5px; }
+  .theme-toggle { position: absolute; top: 0; right: 0;
+    background: var(--surface); border: 1px solid var(--hairline); border-radius: 8px;
+    color: var(--ink-2); font: 11px ui-monospace, Menlo, monospace; letter-spacing: 0.06em;
+    padding: 6px 12px; cursor: pointer; }
+  .theme-toggle:hover { color: var(--ink); }
+  h2 { font-size: 15px; margin: 34px 0 10px; letter-spacing: -0.01em; }
+  table { border-collapse: collapse; width: 100%; background: var(--surface);
+    border: 1px solid var(--hairline); border-radius: 10px; overflow: hidden; font-size: 12.5px; }
+  th { text-align: right; font: 500 10px/1.4 ui-monospace, Menlo, monospace;
+    text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted);
+    padding: 9px 12px; border-bottom: 1px solid var(--hairline); background: var(--head); }
+  td { padding: 7px 12px; border-bottom: 1px solid var(--hairline); text-align: right;
+    font-variant-numeric: tabular-nums; }
+  tr:last-child td { border-bottom: none; }
+  tr:nth-child(even) td { background: var(--stripe); }
+  th.left, td.left { text-align: left; }
+  td.idx { color: var(--muted); width: 24px; }
+  .mono { font-family: ui-monospace, Menlo, monospace; font-size: 11.5px; }
+  .small { font-size: 10.5px; color: var(--muted); }
+  figure { margin: 22px 0; background: var(--surface); border: 1px solid var(--hairline);
+    border-radius: 12px; padding: 16px 18px; }
+  figcaption { font-size: 13.5px; font-weight: 600; margin-bottom: 10px; }
+  .viz svg { display: block; width: 100%; height: auto; }
+  .viz .gridline { stroke: var(--grid); stroke-width: 1; }
+  .viz .axisline { stroke: var(--axis); stroke-width: 1; }
+  .viz .tick-label { fill: var(--muted); font-family: ui-monospace, Menlo, monospace; font-size: 10px; }
+  .viz .axis-title { fill: var(--muted); font-family: ui-monospace, Menlo, monospace;
+    font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; }
+  .viz .series-line { fill: none; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+  .viz .series-dot { stroke: var(--surface); stroke-width: 2; cursor: pointer; transition: r 100ms ease; }
+  .viz .series-dot:hover { r: 6.5; }
+  .viz .crosshair { display: none; }
+  .legend { display: flex; flex-wrap: wrap; gap: 6px 16px; padding-top: 10px; }
+  .legend-item { display: flex; align-items: center; gap: 7px; font-size: 12px; color: var(--ink-2); }
+  .legend-swatch { width: 14px; height: 3px; border-radius: 2px; display: inline-block; }
+  .pt-tip { position: fixed; z-index: 10; pointer-events: none;
+    background: var(--raised); border: 1px solid var(--hairline); border-radius: 8px;
+    padding: 7px 10px; font-size: 12px; box-shadow: 0 8px 30px rgba(0,0,0,.35); max-width: 320px; }
+  .pt-tip .tip-name { font-weight: 600; display: block; margin-bottom: 2px; }
+  .pt-tip .tip-val { font-family: ui-monospace, Menlo, monospace; color: var(--ink-2); }
+  footer { margin-top: 44px; color: var(--muted); font-size: 11px;
+    font-family: ui-monospace, Menlo, monospace; }
+  @media print {
+    body { background: #fff; }
+    figure { break-inside: avoid; }
+    table { break-inside: avoid; }
+  }
+</style></head><body><div class="wrap">
+<header>
+  <div class="eyebrow">Context Bench · Report</div>
+  <h1>${h(title)}</h1>
+  <div class="meta">Generated ${h(generated)} · ${entries.length} run${entries.length === 1 ? "" : "s"}</div>
+  <button class="theme-toggle" onclick="var r=document.documentElement;r.dataset.theme=r.dataset.theme==='light'?'':'light'">◐ dark / light</button>
+</header>
+<h2>Runs</h2>
+<table><thead><tr><th class="left"></th><th class="left">Run</th><th class="left">Engine</th>
+<th class="left">Model</th><th class="left">Machine</th><th class="left">Folder</th></tr></thead>
+<tbody>${runsHtml}</tbody></table>
+${chartsHtml}
+${tablesHtml}
+<footer>context bench — llm context benchmarks</footer>
+</div>
+<script>
+(function () {
+  var tip = document.createElement("div");
+  tip.className = "pt-tip"; tip.hidden = true;
+  var name = document.createElement("span"); name.className = "tip-name";
+  var val = document.createElement("span"); val.className = "tip-val";
+  tip.appendChild(name); tip.appendChild(val);
+  document.body.appendChild(tip);
+  function show(e) {
+    var d = e.target.dataset;
+    name.textContent = d.s;                        // textContent: no HTML injection
+    val.textContent = d.x + "  ·  " + d.v;
+    tip.hidden = false; move(e);
+  }
+  function move(e) {
+    var x = Math.min(e.clientX + 14, window.innerWidth - tip.offsetWidth - 8);
+    tip.style.left = x + "px";
+    tip.style.top = (e.clientY + 14) + "px";
+  }
+  function hide() { tip.hidden = true; }
+  document.querySelectorAll(".series-dot").forEach(function (dot) {
+    dot.addEventListener("mouseenter", show);
+    dot.addEventListener("mousemove", move);
+    dot.addEventListener("mouseleave", hide);
+    dot.addEventListener("click", function (e) { show(e); e.stopPropagation(); });
+  });
+  document.addEventListener("click", hide);
+})();
+</script>
+</body></html>`;
+  }
+
+  // ------------------------------------------------- overview composite PNG
+
+  // Compose all chart canvases into one compact dashboard image.
+  // opts: { title, runs: [{name, color, sub}], charts: [{canvas}], tokens }
+  function composeOverview({ title, runs, charts, tokens }) {
+    const S = 2;                       // everything below in CSS px, drawn at 2x
+    const margin = 26;
+    const gap = 14;
+    const cols = 2;
+    const cellW = charts.length ? charts[0].canvas.width / S : 560;
+    const width = margin * 2 + cols * cellW + (cols - 1) * gap;
+
+    // header layout
+    const legendRows = [];
+    let row = [], used = 0;
+    for (const r of runs) {
+      const w = 24 + (r.name.length + (r.sub ? r.sub.length + 3 : 0)) * 6.2;
+      if (used + w > width - 2 * margin && row.length) { legendRows.push(row); row = []; used = 0; }
+      row.push({ r, x: used });
+      used += w;
+    }
+    if (row.length) legendRows.push(row);
+    const headerH = 64 + legendRows.length * 20;
+
+    const rows = Math.ceil(charts.length / cols);
+    const rowHeights = [];
+    for (let i = 0; i < rows; i++) {
+      const inRow = charts.slice(i * cols, i * cols + cols);
+      rowHeights.push(Math.max(...inRow.map(c => c.canvas.height / S)));
+    }
+    const height = headerH + margin +
+      rowHeights.reduce((a, b) => a + b, 0) + gap * Math.max(0, rows - 1) + margin;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.round(width * S);
+    canvas.height = Math.round(height * S);
+    const ctx = canvas.getContext("2d");
+    ctx.scale(S, S);
+    ctx.fillStyle = tokens.page;
+    ctx.fillRect(0, 0, width, height);
+
+    // header
+    ctx.fillStyle = tokens.muted;
+    ctx.font = "600 9px ui-monospace, Menlo, monospace";
+    ctx.fillText("CONTEXT BENCH · OVERVIEW", margin, 24);
+    ctx.fillStyle = tokens.ink;
+    ctx.font = "650 20px system-ui, sans-serif";
+    ctx.fillText(title, margin, 46);
+    ctx.fillStyle = tokens.muted;
+    ctx.font = "11px system-ui, sans-serif";
+    const generated = new Date().toISOString().slice(0, 16).replace("T", " ");
+    ctx.fillText(generated, width - margin - ctx.measureText(generated).width, 46);
+    legendRows.forEach((items, ri) => {
+      const y = 64 + ri * 20;
+      for (const item of items) {
+        const x = margin + item.x;
+        ctx.fillStyle = item.r.color;
+        ctx.fillRect(x, y - 8, 12, 3.5);
+        ctx.fillStyle = tokens.ink2;
+        ctx.font = "11px system-ui, sans-serif";
+        const label = item.r.sub ? `${item.r.name} — ${item.r.sub}` : item.r.name;
+        ctx.fillText(label, x + 18, y - 2);
+      }
+    });
+    ctx.strokeStyle = tokens.hairline;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(margin, headerH);
+    ctx.lineTo(width - margin, headerH);
+    ctx.stroke();
+
+    // grid of charts
+    let y = headerH + margin;
+    for (let i = 0; i < rows; i++) {
+      for (let j = 0; j < cols; j++) {
+        const chart = charts[i * cols + j];
+        if (!chart) break;
+        const x = margin + j * (cellW + gap);
+        const w = chart.canvas.width / S;
+        const hgt = chart.canvas.height / S;
+        ctx.drawImage(chart.canvas, x, y, w, hgt);
+        ctx.strokeStyle = tokens.hairline;
+        ctx.strokeRect(x + 0.5, y + 0.5, w - 1, hgt - 1);
+      }
+      y += rowHeights[i] + gap;
+    }
+    return canvas;
+  }
+
+
+  // --------------------------------------------------------- PDF report
+
+  function latin1(str) {
+    let out = "";
+    for (const ch of String(str)) {
+      const code = ch.codePointAt(0);
+      if (code <= 255) out += ch;
+      else if (ch === "–" || ch === "—") out += "-";
+      else if (ch === "’" || ch === "‘") out += "'";
+      else if (ch === "“" || ch === "”") out += '"';
+      else if (ch === "≥") out += ">=";
+      else out += "?";
+    }
+    return out.replace(/[\\()]/g, c => "\\" + c);
+  }
+
+  function bytesOf(str) {
+    return Uint8Array.from(str, c => c.charCodeAt(0) & 0xff);
+  }
+
+  // Minimal PDF writer: Helvetica/Courier text, lines, DCT(JPEG) images.
+  function createPdf() {
+    const W = 842, H = 595; // A4 landscape, points
+    const pages = [];
+    let page = null;
+
+    function addPage() {
+      page = { ops: [], images: [] };
+      pages.push(page);
+    }
+    // y is given from the TOP of the page for sanity
+    function text(x, y, str, opts) {
+      const o = opts || {};
+      const font = o.mono ? "/F3" : o.bold ? "/F2" : "/F1";
+      const size = o.size || 10;
+      const color = o.color || [0.09, 0.09, 0.08];
+      page.ops.push(`BT ${font} ${size} Tf ${color.join(" ")} rg 1 0 0 1 ${x.toFixed(1)} ${(H - y).toFixed(1)} Tm (${latin1(str)}) Tj ET`);
+    }
+    function line(x1, y1, x2, y2, gray) {
+      page.ops.push(`${gray ?? 0.75} G 0.7 w ${x1.toFixed(1)} ${(H - y1).toFixed(1)} m ${x2.toFixed(1)} ${(H - y2).toFixed(1)} l S`);
+    }
+    function image(jpeg, x, y, w, h) {
+      const name = `Im${pages.length}_${page.images.length}`;
+      page.images.push({ name, jpeg });
+      page.ops.push(`q ${w.toFixed(1)} 0 0 ${h.toFixed(1)} ${x.toFixed(1)} ${(H - y - h).toFixed(1)} cm /${name} Do Q`);
+    }
+
+    function build() {
+      const parts = [];
+      let offset = 0;
+      const offsets = [0];
+      const push = bytes => { parts.push(bytes); offset += bytes.length; };
+      const addObj = body => {
+        offsets.push(offset);
+        const n = offsets.length - 1;
+        push(bytesOf(`${n} 0 obj\n`));
+        if (body instanceof Uint8Array) push(body); else push(bytesOf(body));
+        push(bytesOf(`\nendobj\n`));
+        return n;
+      };
+
+      push(bytesOf("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n"));
+      const fontF1 = addObj("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>");
+      const fontF2 = addObj("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>");
+      const fontF3 = addObj("<< /Type /Font /Subtype /Type1 /BaseFont /Courier /Encoding /WinAnsiEncoding >>");
+
+      const pageObjNums = [];
+      const kidsPlaceholder = [];
+      for (const p of pages) {
+        const imageObjNums = [];
+        for (const img of p.images) {
+          const num = addObj(concat([
+            bytesOf(`<< /Type /XObject /Subtype /Image /Width ${img.jpeg.width} /Height ${img.jpeg.height} ` +
+              `/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ${img.jpeg.bytes.length} >>\nstream\n`),
+            img.jpeg.bytes,
+            bytesOf("\nendstream"),
+          ]));
+          imageObjNums.push({ name: img.name, num });
+        }
+        const content = bytesOf(p.ops.join("\n"));
+        const contentNum = addObj(concat([
+          bytesOf(`<< /Length ${content.length} >>\nstream\n`), content, bytesOf("\nendstream"),
+        ]));
+        const xobjects = imageObjNums.map(i => `/${i.name} ${i.num} 0 R`).join(" ");
+        kidsPlaceholder.push({ contentNum, xobjects });
+        pageObjNums.push(null); // filled after pages object number known
+      }
+
+      // pages tree object comes after all content, then page objects reference it
+      const pagesNumGuess = offsets.length + pages.length; // pages obj is created after page objects
+      const realPageNums = [];
+      for (const k of kidsPlaceholder) {
+        const num = addObj(`<< /Type /Page /Parent ${pagesNumGuess} 0 R /MediaBox [0 0 ${W} ${H}] ` +
+          `/Resources << /Font << /F1 ${fontF1} 0 R /F2 ${fontF2} 0 R /F3 ${fontF3} 0 R >> ` +
+          `/XObject << ${k.xobjects} >> >> /Contents ${k.contentNum} 0 R >>`);
+        realPageNums.push(num);
+      }
+      const pagesNum = addObj(`<< /Type /Pages /Kids [${realPageNums.map(n => `${n} 0 R`).join(" ")}] /Count ${realPageNums.length} >>`);
+      const catalogNum = addObj(`<< /Type /Catalog /Pages ${pagesNum} 0 R >>`);
+
+      const xrefStart = offset;
+      let xref = `xref\n0 ${offsets.length}\n0000000000 65535 f \n`;
+      for (let i = 1; i < offsets.length; i++) xref += String(offsets[i]).padStart(10, "0") + " 00000 n \n";
+      push(bytesOf(xref));
+      push(bytesOf(`trailer\n<< /Size ${offsets.length} /Root ${catalogNum} 0 R >>\nstartxref\n${xrefStart}\n%%EOF\n`));
+      return new Blob(parts, { type: "application/pdf" });
+
+      function concat(arrays) {
+        let total = 0;
+        for (const a of arrays) total += a.length;
+        const out = new Uint8Array(total);
+        let pos = 0;
+        for (const a of arrays) { out.set(a, pos); pos += a.length; }
+        return out;
+      }
+    }
+
+    return { W, H, addPage, text, line, image, build };
+  }
+
+  // charts: [{title, jpeg:{bytes,width,height}}]
+  function buildPdfReport(title, entries, tables, charts) {
+    const pdf = createPdf();
+    const M = 46;
+    const generated = new Date().toISOString().slice(0, 19).replace("T", " ");
+
+    // --- cover ---
+    pdf.addPage();
+    pdf.text(M, 56, "CONTEXT BENCH · REPORT", { mono: true, size: 9, color: [0.55, 0.53, 0.5] });
+    pdf.text(M, 86, title, { bold: true, size: 24 });
+    pdf.text(M, 106, `Generated ${generated}  ·  ${entries.length} run${entries.length === 1 ? "" : "s"}`,
+      { size: 10.5, color: [0.32, 0.32, 0.3] });
+    pdf.line(M, 122, pdf.W - M, 122, 0.2);
+    let y = 150;
+    pdf.text(M, y, "Runs", { bold: true, size: 13 });
+    y += 22;
+    entries.forEach((e, i) => {
+      const s = e.detail.summary;
+      pdf.text(M, y, `${i + 1}.  ${e.name}`, { bold: true, size: 11 });
+      y += 15;
+      pdf.text(M + 16, y, `${s.engine} · ${s.model}${s.machine ? " · " + s.machine : ""}`, { size: 9.5, color: [0.32, 0.32, 0.3] });
+      y += 13;
+      if (s.hardware) { pdf.text(M + 16, y, s.hardware, { size: 9, color: [0.55, 0.53, 0.5] }); y += 13; }
+      pdf.text(M + 16, y, s.folder, { mono: true, size: 8, color: [0.55, 0.53, 0.5] });
+      y += 20;
+    });
+
+    // --- chart pages ---
+    for (const chart of charts) {
+      pdf.addPage();
+      pdf.text(M, 44, chart.title, { bold: true, size: 13 });
+      pdf.line(M, 56, pdf.W - M, 56, 0.2);
+      const maxW = pdf.W - 2 * M;
+      const maxH = pdf.H - 100;
+      const ratio = Math.min(maxW / chart.jpeg.width, maxH / chart.jpeg.height);
+      const w = chart.jpeg.width * ratio;
+      const h = chart.jpeg.height * ratio;
+      pdf.image(chart.jpeg, M + (maxW - w) / 2, 72, w, h);
+    }
+
+    // --- data tables (monospace) ---
+    const lineHeight = 12;
+    let ty = Infinity;
+    const newDataPage = () => {
+      pdf.addPage();
+      pdf.text(M, 44, "Data", { bold: true, size: 13 });
+      pdf.line(M, 56, pdf.W - M, 56, 0.2);
+      ty = 78;
+    };
+    const room = () => pdf.H - 40 - ty;
+    for (const table of tables) {
+      const widths = table.headers.map((h, i) =>
+        Math.max(String(h).length, ...table.rows.map(r => (r[i] == null ? 1 : String(r[i]).length))) + 2);
+      const headerLine = table.headers.map((h, i) => pad(h, widths[i])).join("");
+      const neededRows = table.rows.length + 3;
+      if (ty === Infinity || room() < Math.min(neededRows, 6) * lineHeight) newDataPage();
+      pdf.text(M, ty, table.title, { bold: true, size: 10.5 });
+      ty += 16;
+      pdf.text(M, ty, headerLine, { mono: true, size: 8.5, color: [0.45, 0.44, 0.4] });
+      ty += 4;
+      pdf.line(M, ty, pdf.W - M, ty, 0.6);
+      ty += lineHeight - 2;
+      for (const row of table.rows) {
+        if (room() < lineHeight) {
+          newDataPage();
+          pdf.text(M, ty, headerLine, { mono: true, size: 8.5, color: [0.45, 0.44, 0.4] });
+          ty += lineHeight;
+        }
+        pdf.text(M, ty, row.map((v, i) => pad(v, widths[i])).join(""), { mono: true, size: 8.5 });
+        ty += lineHeight;
+      }
+      ty += 14;
+    }
+
+    return pdf.build();
+  }
+
+  function download(blob, filename) {
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    setTimeout(() => { URL.revokeObjectURL(a.href); a.remove(); }, 2000);
+  }
+
+  window.CBExport = {
+    makeZip, svgToCanvas, canvasToPngBytes, canvasToJpeg,
+    buildResultsCsv, buildBatchCsv, buildTables, buildComparisonTxt,
+    buildHtmlReport, buildPdfReport, composeOverview, download,
+  };
+})();

--- a/webui_static/index.html
+++ b/webui_static/index.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>LLM Context Bench</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>⏱</text></svg>">
+<link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<div class="shell">
+  <aside class="rail">
+    <div class="wordmark">
+      <span class="wordmark-sigil" aria-hidden="true"></span>
+      <div>
+        <div class="wordmark-title">Context Bench</div>
+        <div class="wordmark-sub">LLM benchmarks</div>
+      </div>
+    </div>
+    <nav class="nav" id="nav">
+      <a href="#run" data-view="run">
+        <svg class="nav-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 2.8v10.4l8-5.2z"/></svg>
+        Run</a>
+      <a href="#results" data-view="results">
+        <svg class="nav-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><path d="M2.5 4h11M2.5 8h11M2.5 12h7"/></svg>
+        Results</a>
+      <a href="#compare" data-view="compare">
+        <svg class="nav-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 12.5l4-4 3 2.5 5-6"/><path d="M10.5 5H14v3.5"/></svg>
+        Compare</a>
+      <a href="#endpoints" data-view="endpoints">
+        <svg class="nav-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="2.5" width="12" height="4.6" rx="1.2"/><rect x="2" y="8.9" width="12" height="4.6" rx="1.2"/><path d="M4.6 4.8h.01M4.6 11.2h.01"/></svg>
+        Endpoints</a>
+      <a href="#tools" data-view="tools">
+        <svg class="nav-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><path d="M3 5h10M3 11h10"/><circle cx="6" cy="5" r="1.7"/><circle cx="10" cy="11" r="1.7"/></svg>
+        Tools</a>
+    </nav>
+    <div class="rail-foot">
+      <div class="hw-readout" id="hwReadout" title="">–</div>
+      <div class="mlx-badge" id="mlxBadge"></div>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle color theme">◐ theme</button>
+    </div>
+  </aside>
+  <main class="main" id="main">
+    <section class="view" id="view-run" hidden></section>
+    <section class="view" id="view-results" hidden></section>
+    <section class="view" id="view-compare" hidden></section>
+    <section class="view" id="view-endpoints" hidden></section>
+    <section class="view" id="view-tools" hidden></section>
+  </main>
+</div>
+<div class="modal-backdrop" id="modalBackdrop" hidden>
+  <div class="modal" id="modal" role="dialog" aria-modal="true"></div>
+</div>
+<div class="toast-stack" id="toastStack"></div>
+<script src="/static/charts.js"></script>
+<script src="/static/export.js"></script>
+<script src="/static/core.js"></script>
+<script src="/static/report.js"></script>
+<script src="/static/view-run.js"></script>
+<script src="/static/view-results.js"></script>
+<script src="/static/view-compare.js"></script>
+<script src="/static/view-endpoints.js"></script>
+<script src="/static/view-tools.js"></script>
+<script src="/static/app.js"></script>
+</body>
+</html>

--- a/webui_static/report.js
+++ b/webui_static/report.js
@@ -1,0 +1,184 @@
+/* Report/export pipeline shared by Compare and the result detail dialog:
+   renders full-size charts offscreen and hands them to CBExport as
+   ZIP (one overview PNG + CSV + TXT), interactive HTML report or PDF. */
+
+(function () {
+  "use strict";
+
+  const { fmt, toast, seriesColor, ctxNum, metricsForKeys } = CB;
+
+  function metricsForEntries(entries) {
+    return metricsForKeys(new Set(entries.flatMap(e => e.detail.summary.columns)));
+  }
+
+  // Batch charts: prompt + end-to-end are always there; the pure decode rate
+  // only when the engine recorded it (decode_tps_total from server usage).
+  function batchChartDefs(entries) {
+    const withBatch = entries.filter(e => e.detail.batch_data && e.detail.batch_data.length);
+    if (!withBatch.length) return [];
+    const defs = [
+      { key: "batch_prompt", title: "Batch — prompt throughput [tok/s]", field: "prompt_tps" },
+      { key: "batch_e2e", title: "Batch — end-to-end gen throughput [tok/s]", field: "generation_tps" },
+    ];
+    if (withBatch.some(e => e.detail.batch_data.some(b => b.decode_tps_total != null))) {
+      defs.push({ key: "batch_decode", title: "Batch — decode throughput [tok/s]", field: "decode_tps_total" });
+    }
+    if (withBatch.some(e => e.detail.batch_data.some(b => b.host_memory_gb != null))) {
+      defs.push({ key: "batch_host_mem", title: "Batch — host RAM [GB]", field: "host_memory_gb" });
+    }
+    return defs;
+  }
+
+  // Renders all charts (metric sweeps + batch) for the given runs offscreen.
+  // opts.theme: null (current UI theme) | "light" — forced for print exports.
+  // opts.raw: return class-based SVG markup (themable + interactive in the
+  //           HTML report) instead of rasterized canvases.
+  async function renderExportCharts(entries, metrics, opts) {
+    const { theme = null, width = 1160, height = 480, batchHeight = 420, legend = true, raw = false } = opts || {};
+    const stage = document.createElement("div");
+    stage.style.cssText = `position:fixed;left:-12000px;top:0;width:${width}px`;
+    if (theme === "light") stage.className = "force-light";
+    document.body.appendChild(stage);
+    const surface = () => getComputedStyle(stage).getPropertyValue("--surface").trim() || "#fff";
+    const charts = [];
+
+    const seriesFor = getPoints => entries
+      .map(e => ({ name: e.name, color: seriesColor(e.slot || 0), points: getPoints(e) }))
+      .filter(s => s.points.some(p => p[1] != null && isFinite(p[1])));
+
+    const render = async (series, chartOpts, key, title) => {
+      if (!series.length) return;
+      stage.innerHTML = "";
+      Charts.lineChart(stage, {
+        series, logX: true, width, legend: false,
+        svgTitle: raw ? undefined : title,
+        svgLegend: raw ? false : legend,
+        ...chartOpts,
+      });
+      const svg = stage.querySelector("svg");
+      if (!svg) return;
+      charts.push(raw
+        ? { key, title, svg: svg.outerHTML }
+        : { key, title, canvas: await CBExport.svgToCanvas(svg, 2, surface()) });
+    };
+
+    try {
+      for (const metric of metrics) {
+        await render(
+          seriesFor(e => e.detail.results.map(r => [ctxNum(r.context_size), r[metric.key]])),
+          { height, seconds: metric.seconds, xLabel: "context (tokens ×1000)", yLabel: metric.unit },
+          metric.key,
+          `${metric.label} across context size [${metric.unit}]`,
+        );
+      }
+      for (const def of batchChartDefs(entries)) {
+        await render(
+          seriesFor(e => (e.detail.batch_data || []).map(b => [b.batch_size, b[def.field]])),
+          { height: batchHeight, xLabel: "batch size (parallel clients)", yLabel: def.title.match(/\[(.+)\]/)[1], xTickFormat: v => String(v) },
+          def.key,
+          def.title,
+        );
+      }
+    } finally {
+      stage.remove();
+    }
+    return charts;
+  }
+
+  function themeTokens() {
+    const styles = getComputedStyle(document.documentElement);
+    const tok = name => styles.getPropertyValue(name).trim();
+    return {
+      page: tok("--page") || "#fff",
+      surface: tok("--surface") || "#fff",
+      ink: tok("--ink") || "#111",
+      ink2: tok("--ink-2") || "#555",
+      muted: tok("--muted") || "#888",
+      hairline: tok("--hairline") || "#ddd",
+    };
+  }
+
+  // format: "zip" | "html" | "pdf"
+  async function exportRuns(entries, format, baseName, title) {
+    const metrics = metricsForEntries(entries);
+    const tables = CBExport.buildTables(entries, metrics, fmt);
+    const stamp = new Date().toISOString().slice(0, 16).replace(/[T:]/g, "-");
+
+    if (format === "zip") {
+      // one compact dashboard PNG instead of a folder of single charts
+      const charts = await renderExportCharts(entries, metrics,
+        { width: 720, height: 330, batchHeight: 300, legend: false });
+      const overview = CBExport.composeOverview({
+        title,
+        // entry names already carry the model, so the sub only adds context
+        runs: entries.map(e => ({
+          name: e.name,
+          color: seriesColor(e.slot || 0),
+          sub: [e.detail.summary.engine, e.detail.summary.machine].filter(Boolean).join(" · "),
+        })),
+        charts,
+        tokens: themeTokens(),
+      });
+      const encoder = new TextEncoder();
+      const files = [{ name: "overview.png", data: await CBExport.canvasToPngBytes(overview) }];
+      files.push({ name: "results.csv", data: encoder.encode(CBExport.buildResultsCsv(entries)) });
+      const batchCsv = CBExport.buildBatchCsv(entries);
+      if (batchCsv) files.push({ name: "batch_results.csv", data: encoder.encode(batchCsv) });
+      files.push({ name: "comparison.txt", data: encoder.encode(CBExport.buildComparisonTxt(entries, tables, title)) });
+      CBExport.download(CBExport.makeZip(files), `${baseName}_${stamp}.zip`);
+      return files.length + " files zipped";
+    }
+
+    if (format === "html") {
+      // interactive SVG charts: theme with the report's toggle, points show
+      // their values on hover/click
+      const charts = await renderExportCharts(entries, metrics,
+        { raw: true, width: 1060, height: 420, batchHeight: 380 });
+      const legend = entries.map(e => ({ name: e.name, color: seriesColor(e.slot || 0) }));
+      const html = CBExport.buildHtmlReport(title, entries, tables, charts, legend);
+      CBExport.download(new Blob([html], { type: "text/html" }), `${baseName}_${stamp}.html`);
+      return "HTML report saved";
+    }
+
+    // pdf — always the print-friendly light style
+    const charts = await renderExportCharts(entries, metrics, { theme: "light" });
+    const chartData = [];
+    for (const c of charts) chartData.push({ title: c.title, jpeg: await CBExport.canvasToJpeg(c.canvas) });
+    const pdf = CBExport.buildPdfReport(title, entries, tables, chartData);
+    CBExport.download(pdf, `${baseName}_${stamp}.pdf`);
+    return "PDF report saved";
+  }
+
+  function wireExportGroup(container, getEntries, baseName, getTitle) {
+    container.querySelectorAll("[data-export]").forEach(btn => {
+      btn.addEventListener("click", async () => {
+        const group = btn.closest(".export-group");
+        group.querySelectorAll(".btn").forEach(b => { b.disabled = true; });
+        const original = btn.textContent;
+        btn.textContent = "…";
+        try {
+          const entries = await getEntries();
+          if (!entries.length) { toast("Nothing selected to export.", true); return; }
+          const message = await exportRuns(entries, btn.dataset.export, baseName, getTitle(entries));
+          toast("Export ready — " + message + ".");
+        } catch (e) {
+          toast("Export failed: " + e.message, true);
+        } finally {
+          btn.textContent = original;
+          group.querySelectorAll(".btn").forEach(b => { b.disabled = false; });
+        }
+      });
+    });
+  }
+
+  function exportGroupHtml() {
+    return `<span class="export-group">
+      <span class="export-label">Export</span>
+      <button class="btn small" data-export="zip" title="Overview PNG + CSV + plain text, zipped">ZIP</button>
+      <button class="btn small" data-export="html" title="Self-contained HTML report (dark/light toggle)">HTML</button>
+      <button class="btn small" data-export="pdf" title="PDF report">PDF</button>
+    </span>`;
+  }
+
+  CB.report = { metricsForEntries, batchChartDefs, wireExportGroup, exportGroupHtml };
+})();

--- a/webui_static/styles.css
+++ b/webui_static/styles.css
@@ -1,0 +1,602 @@
+/* LLM Context Bench — instrument-panel UI.
+   Identity: engraved panel labels (mono, letterspaced), a log-scale sweep rule
+   under every page title, LED status lamps. Chrome: warm gray family.
+   Series colors: validated categorical palette (see charts.js usage). */
+
+:root {
+  --page: #0c0c0b;
+  --page-glow: #161615;
+  --surface: #1a1a19;
+  --raised: #232322;
+  --sunken: #131312;
+  --ink: #f4f3ee;
+  --ink-2: #c3c2b7;
+  --muted: #8b897f;
+  --hairline: #2c2c2a;
+  --border: rgba(255, 255, 255, 0.10);
+  --accent: #3987e5;
+  --accent-soft: rgba(57, 135, 229, 0.16);
+  --accent-ink: #ffffff;
+  --good: #0ca30c;
+  --warning: #fab219;
+  --serious: #ec835a;
+  --critical: #d03b3b;
+  --s1: #3987e5; --s2: #199e70; --s3: #c98500; --s4: #008300;
+  --s5: #9085e9; --s6: #e66767; --s7: #d55181; --s8: #d95926;
+  --grid: #262624;
+  --axis: #383835;
+  --shadow-panel: 0 1px 0 rgba(255, 255, 255, 0.03) inset, 0 10px 30px -18px rgba(0, 0, 0, 0.9);
+  --shadow-pop: 0 24px 70px -18px rgba(0, 0, 0, 0.8);
+  --key-light: rgba(255, 255, 255, 0.05);
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color-scheme: dark;
+}
+:root[data-theme="light"], .force-light {
+  --page: #efeee8;
+  --page-glow: #f5f4ef;
+  --surface: #fcfcfb;
+  --raised: #f4f3ee;
+  --sunken: #f0efea;
+  --ink: #171614;
+  --ink-2: #52514e;
+  --muted: #8b897f;
+  --hairline: #e0dfd7;
+  --border: rgba(11, 11, 11, 0.12);
+  --accent: #2a78d6;
+  --accent-soft: rgba(42, 120, 214, 0.12);
+  --s1: #2a78d6; --s2: #1baf7a; --s3: #eda100; --s4: #008300;
+  --s5: #4a3aa7; --s6: #e34948; --s7: #e87ba4; --s8: #eb6834;
+  --grid: #e5e4dc;
+  --axis: #c6c5bb;
+  --shadow-panel: 0 1px 2px rgba(30, 28, 20, 0.05), 0 12px 32px -22px rgba(30, 28, 20, 0.35);
+  --shadow-pop: 0 24px 70px -24px rgba(30, 28, 20, 0.45);
+  --key-light: rgba(255, 255, 255, 0.7);
+  color-scheme: light;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background:
+    radial-gradient(1100px 500px at 62% -140px, var(--page-glow), transparent 70%),
+    var(--page);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+button { font: inherit; color: inherit; }
+input, select, textarea { font: inherit; }
+::selection { background: color-mix(in srgb, var(--accent) 32%, transparent); }
+* { scrollbar-width: thin; scrollbar-color: var(--hairline) transparent; }
+::-webkit-scrollbar { width: 9px; height: 9px; }
+::-webkit-scrollbar-thumb { background: var(--hairline); border-radius: 5px; }
+::-webkit-scrollbar-track { background: transparent; }
+
+/* ---------- shell ---------- */
+.shell { display: flex; min-height: 100vh; }
+.rail {
+  width: 228px;
+  flex: 0 0 228px;
+  border-right: 1px solid var(--hairline);
+  padding: 22px 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+.wordmark { display: flex; gap: 10px; align-items: center; padding: 2px 10px 6px; }
+.wordmark-sigil {
+  width: 26px; height: 26px; flex: none;
+  border-radius: 7px;
+  position: relative;
+  background: var(--accent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+.wordmark-sigil::after {
+  content: ""; position: absolute; inset: 6px;
+  background: #fff;
+  clip-path: polygon(0 100%, 0 52%, 30% 68%, 62% 16%, 100% 40%, 100% 100%);
+}
+.wordmark-title { font-size: 14px; font-weight: 650; letter-spacing: -0.01em; }
+.wordmark-sub { font-size: 11px; color: var(--muted); margin-top: 1px; }
+
+.nav { display: flex; flex-direction: column; gap: 2px; }
+.nav a {
+  display: flex; align-items: center; gap: 11px;
+  padding: 8px 11px;
+  border-radius: 8px;
+  color: var(--ink-2);
+  text-decoration: none;
+  font-size: 13.5px;
+}
+.nav a:hover { background: var(--raised); color: var(--ink); }
+.nav a.active {
+  background: var(--accent-soft);
+  color: var(--ink);
+  font-weight: 550;
+}
+.nav-icon { width: 16px; height: 16px; flex: none; color: var(--muted); }
+.nav a:hover .nav-icon { color: var(--ink-2); }
+.nav a.active .nav-icon { color: var(--accent); }
+
+.rail-foot { margin-top: auto; display: flex; flex-direction: column; gap: 9px; padding: 0 8px; }
+.hw-readout {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--muted);
+  line-height: 1.55;
+  border-top: 1px solid var(--hairline);
+  padding-top: 12px;
+  overflow-wrap: anywhere;
+  letter-spacing: 0.02em;
+}
+.mlx-badge { font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; }
+.mlx-badge .on { color: var(--good); }
+.mlx-badge .off { color: var(--muted); }
+.theme-toggle {
+  align-self: flex-start;
+  background: var(--sunken); border: 1px solid var(--hairline); border-radius: 6px;
+  color: var(--muted); font-family: var(--mono); font-size: 10px;
+  padding: 4px 9px; cursor: pointer; letter-spacing: 0.07em;
+}
+.theme-toggle:hover { color: var(--ink); border-color: var(--border); }
+
+.main { flex: 1; min-width: 0; padding: 30px 38px 70px; }
+
+/* ---------- typography & page header ---------- */
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  gap: 16px; margin-bottom: 22px;
+}
+.page-title { font-size: 20px; font-weight: 650; letter-spacing: -0.015em; margin: 5px 0 0; }
+.page-sub { color: var(--ink-2); font-size: 13px; margin-top: 5px; max-width: 640px; }
+
+.unit { font-family: var(--mono); font-size: 0.82em; color: var(--muted); letter-spacing: 0.02em; }
+.num { font-variant-numeric: tabular-nums; font-family: var(--mono); }
+
+/* ---------- panels / cards ---------- */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  padding: 18px 20px;
+  box-shadow: var(--shadow-panel);
+}
+.panel + .panel { margin-top: 16px; }
+.panel-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
+.panel-title { font-size: 14px; font-weight: 650; letter-spacing: -0.01em; }
+.section-label {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--muted);
+  display: flex; align-items: center; gap: 10px;
+  margin: 18px 0 12px;
+}
+.section-label::after { content: ""; flex: 1; height: 1px; background: var(--hairline); }
+.section-label:first-child { margin-top: 0; }
+
+.grid-2 { display: grid; grid-template-columns: minmax(0, 5fr) minmax(0, 4fr); gap: 16px; align-items: start; }
+@media (max-width: 1100px) { .grid-2 { grid-template-columns: 1fr; } }
+
+/* ---------- forms ---------- */
+.field { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.field label { font-size: 12px; color: var(--ink-2); }
+.field input[type="text"], .field input[type="number"], .field input[type="password"],
+.field select, .field textarea {
+  background: var(--sunken);
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  color: var(--ink);
+  padding: 7px 11px;
+  font-size: 13.5px;
+  width: 100%;
+  transition: border-color 120ms ease;
+}
+.field input:hover, .field select:hover, .field textarea:hover { border-color: var(--border); }
+.field input:focus-visible, .field select:focus-visible, .field textarea:focus-visible,
+button:focus-visible, a:focus-visible, [tabindex]:focus-visible,
+.ctx-chip input:focus-visible + span {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.field .hint { font-size: 11px; color: var(--muted); }
+.field input::placeholder, .field textarea::placeholder { color: color-mix(in srgb, var(--muted) 75%, transparent); }
+.form-row { display: grid; gap: 12px; margin-bottom: 12px; }
+.form-row.cols-2 { grid-template-columns: 1fr 1fr; }
+.form-row.cols-3 { grid-template-columns: 1fr 1fr 1fr; }
+.form-row.cols-4 { grid-template-columns: 1fr 1fr 1fr 1fr; }
+@media (max-width: 900px) { .form-row.cols-3, .form-row.cols-4 { grid-template-columns: 1fr 1fr; } }
+
+.check { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--ink-2); cursor: pointer; }
+.check input { accent-color: var(--accent); width: 15px; height: 15px; }
+
+.btn {
+  background: var(--raised);
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  padding: 7px 15px;
+  cursor: pointer;
+  font-size: 13.5px;
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 var(--key-light);
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.btn:hover { border-color: var(--border); background: color-mix(in srgb, var(--raised) 82%, var(--ink) 5%); }
+.btn:active { box-shadow: none; }
+.btn.primary {
+  background: var(--accent); border-color: color-mix(in srgb, var(--accent) 70%, #000 12%);
+  color: var(--accent-ink); font-weight: 600;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22);
+}
+.btn.primary:hover { background: color-mix(in srgb, var(--accent) 86%, var(--ink) 14%); }
+.btn.danger { color: var(--critical); }
+.btn.danger:hover { border-color: var(--critical); }
+.btn.small { padding: 4px 11px; font-size: 12px; border-radius: 7px; }
+.btn.ghost { background: none; box-shadow: none; }
+.btn:disabled { opacity: 0.42; cursor: not-allowed; }
+.btn-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+
+/* context chips */
+.ctx-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.ctx-chip { position: relative; }
+.ctx-chip input { position: absolute; opacity: 0; inset: 0; cursor: pointer; }
+.ctx-chip span {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 4px 11px;
+  border-radius: 7px;
+  border: 1px solid var(--hairline);
+  background: var(--sunken);
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.ctx-chip span:hover { color: var(--ink-2); border-color: var(--border); }
+.ctx-chip input:checked + span {
+  background: var(--accent-soft);
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--hairline));
+  color: var(--ink);
+}
+
+/* collapsible advanced */
+details.advanced { border-top: 1px solid var(--hairline); margin-top: 16px; padding-top: 12px; }
+details.advanced summary {
+  cursor: pointer; list-style: none;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--muted);
+}
+details.advanced summary:hover { color: var(--ink-2); }
+details.advanced summary::before { content: "▸ "; }
+details.advanced[open] summary::before { content: "▾ "; }
+details.advanced > div { margin-top: 14px; }
+
+/* ---------- LEDs & status ---------- */
+.led {
+  width: 9px; height: 9px; border-radius: 3px; flex: none;
+  background: var(--muted);
+}
+.led.running { background: var(--accent); box-shadow: 0 0 9px color-mix(in srgb, var(--accent) 75%, transparent); animation: pulse 1.6s ease-in-out infinite; }
+.led.starting { background: var(--muted); animation: pulse 1.6s ease-in-out infinite; }
+.led.done, .led.on { background: var(--good); box-shadow: 0 0 8px color-mix(in srgb, var(--good) 55%, transparent); }
+.led.failed, .led.off { background: var(--critical); box-shadow: 0 0 8px color-mix(in srgb, var(--critical) 55%, transparent); }
+.led.stopped { background: var(--warning); }
+.led.idle { background: var(--hairline); box-shadow: none; }
+@keyframes pulse { 50% { opacity: 0.35; } }
+@media (prefers-reduced-motion: reduce) {
+  .led { animation: none !important; }
+  * { transition: none !important; }
+}
+
+/* ---------- run monitor ---------- */
+.run-card {
+  border: 1px solid var(--hairline); border-radius: 12px;
+  background: var(--surface); margin-bottom: 14px; overflow: hidden;
+  box-shadow: var(--shadow-panel);
+}
+.run-card-head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 13px 17px;
+  border-bottom: 1px solid var(--hairline);
+  flex-wrap: wrap;
+}
+.run-card-title { font-weight: 600; font-size: 13.5px; }
+.run-card-meta { font-family: var(--mono); font-size: 10.5px; color: var(--muted); letter-spacing: 0.03em; }
+.run-card-spacer { flex: 1; }
+
+.readout {
+  display: flex; gap: 0; flex-wrap: wrap;
+  border-bottom: 1px solid var(--hairline);
+  background: var(--sunken);
+}
+.readout-cell {
+  min-width: 110px; flex: 1;
+  padding: 13px 17px;
+  border-right: 1px solid var(--hairline);
+}
+.readout-cell:last-child { border-right: none; }
+.readout-cell .eyebrow { display: block; margin-bottom: 3px; font-size: 9px; }
+.readout-value {
+  font-family: var(--mono); font-size: 23px; font-weight: 600;
+  font-variant-numeric: tabular-nums; letter-spacing: -0.01em;
+}
+.readout-value .unit { font-size: 11px; }
+
+.ctx-lane { display: flex; gap: 5px; flex-wrap: wrap; padding: 11px 17px; border-bottom: 1px solid var(--hairline); }
+.ctx-step {
+  font-family: var(--mono); font-size: 10.5px;
+  padding: 2px 8px; border-radius: 5px;
+  border: 1px solid var(--hairline); color: var(--muted);
+  background: var(--sunken);
+}
+.ctx-step.done { border-color: color-mix(in srgb, var(--good) 55%, var(--hairline)); color: var(--good); }
+.ctx-step.active { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+
+.console {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--ink-2);
+  background: var(--sunken);
+  padding: 12px 17px;
+  max-height: 45vh;
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  margin: 0;
+}
+
+/* ---------- tables ---------- */
+.tbl-wrap { overflow-x: auto; }
+table.tbl { border-collapse: collapse; width: 100%; font-size: 12.5px; }
+.tbl th {
+  text-align: right;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.09em; text-transform: uppercase;
+  color: var(--muted); font-weight: 500;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--axis);
+  white-space: nowrap;
+}
+.tbl th:first-child, .tbl td:first-child { text-align: left; }
+.tbl td {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--hairline);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.tbl tbody tr:hover { background: var(--raised); }
+
+/* ---------- results list ---------- */
+.results-toolbar { display: flex; gap: 10px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
+.results-toolbar input[type="text"] {
+  background: var(--surface); border: 1px solid var(--hairline); border-radius: 8px;
+  color: var(--ink); padding: 7px 12px; width: 280px; font-size: 13px;
+}
+.result-row {
+  display: grid;
+  grid-template-columns: 24px minmax(220px, 2fr) 110px 150px 130px 110px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 11px 15px;
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  background: var(--surface);
+  margin-bottom: 8px;
+  box-shadow: var(--shadow-panel);
+  transition: border-color 120ms ease;
+}
+@media (max-width: 1150px) {
+  .result-row { grid-template-columns: 24px minmax(180px, 1fr) 110px auto; }
+  .result-row .r-machine, .result-row .r-ctx, .result-row .r-spark,
+  .result-row .r-date, .result-row .r-peak { display: none; }
+}
+.result-row:hover { border-color: var(--border); }
+.result-row input[type="checkbox"] { accent-color: var(--accent); width: 15px; height: 15px; }
+.r-name { min-width: 0; }
+.r-label { font-weight: 600; font-size: 13.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.r-model { font-family: var(--mono); font-size: 10.5px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 1px; }
+.tag {
+  display: inline-block;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em;
+  border: 1px solid var(--hairline); border-radius: 5px;
+  padding: 2px 8px; color: var(--ink-2);
+  background: var(--sunken);
+  white-space: nowrap;
+}
+.r-peak { text-align: right; }
+.r-peak .v { font-family: var(--mono); font-size: 15px; font-weight: 600; font-variant-numeric: tabular-nums; }
+.r-date, .r-machine, .r-ctx { font-family: var(--mono); font-size: 10.5px; color: var(--muted); }
+.r-actions { display: flex; gap: 6px; justify-content: flex-end; align-items: center; }
+.spark { display: block; }
+.spark path { fill: none; stroke: var(--s1); stroke-width: 1.5; }
+.empty {
+  border: 1px dashed var(--hairline);
+  border-radius: 12px;
+  padding: 38px 30px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+  background: color-mix(in srgb, var(--surface) 45%, transparent);
+}
+.empty strong { color: var(--ink-2); display: block; margin-bottom: 5px; font-size: 14px; }
+
+/* ---------- compare ---------- */
+.compare-layout { display: grid; grid-template-columns: 300px minmax(0, 1fr); gap: 16px; align-items: start; }
+@media (max-width: 1100px) { .compare-layout { grid-template-columns: 1fr; } }
+.pick-list { display: flex; flex-direction: column; gap: 6px; max-height: calc(100vh - 330px); overflow: auto; }
+.pick-row {
+  display: flex; gap: 10px; align-items: center;
+  padding: 8px 10px; border-radius: 8px; border: 1px solid transparent;
+  cursor: pointer;
+}
+.pick-row:hover { background: var(--raised); }
+.pick-row.on { border-color: var(--hairline); background: var(--sunken); }
+.pick-swatch { width: 10px; height: 10px; border-radius: 3px; flex: none; background: var(--hairline); }
+.pick-name { font-size: 12.5px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pick-sub { font-family: var(--mono); font-size: 9.5px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 1px; }
+
+.metric-tabs { display: flex; gap: 4px; flex-wrap: wrap; margin-bottom: 12px; }
+.metric-tab {
+  background: none; border: 1px solid transparent; border-radius: 7px;
+  padding: 5px 12px; cursor: pointer; font-size: 12.5px; color: var(--muted);
+}
+.metric-tab:hover { color: var(--ink); background: var(--raised); }
+.metric-tab.active {
+  background: var(--surface); color: var(--ink);
+  border-color: var(--hairline);
+  box-shadow: inset 0 -2px 0 var(--accent), var(--shadow-panel);
+}
+.metric-tab.active .unit { color: var(--accent); }
+.chart-controls { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; margin-bottom: 8px; }
+.chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+@media (max-width: 1250px) { .chart-grid { grid-template-columns: 1fr; } }
+
+/* ---------- charts ---------- */
+.viz { position: relative; }
+.viz svg { display: block; width: 100%; height: auto; }
+.viz .gridline { stroke: var(--grid); stroke-width: 1; }
+.viz .axisline { stroke: var(--axis); stroke-width: 1; }
+.viz .tick-label { fill: var(--muted); font-family: var(--mono); font-size: 10px; }
+.viz .axis-title { fill: var(--muted); font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; }
+.viz .series-line { fill: none; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+.viz .series-dot { stroke: var(--surface); stroke-width: 2; }
+.viz .crosshair { stroke: var(--muted); stroke-width: 1; opacity: 0.6; }
+.viz-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 9px 11px;
+  font-size: 11.5px;
+  min-width: 150px;
+  box-shadow: var(--shadow-pop);
+  z-index: 5;
+}
+.viz-tooltip .tt-title { font-family: var(--mono); font-size: 10px; color: var(--muted); margin-bottom: 6px; letter-spacing: 0.08em; }
+.viz-tooltip .tt-row { display: flex; align-items: center; gap: 7px; padding: 1.5px 0; }
+.viz-tooltip .tt-swatch { width: 8px; height: 8px; border-radius: 2px; flex: none; }
+.viz-tooltip .tt-name { color: var(--ink-2); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; }
+.viz-tooltip .tt-val { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.legend { display: flex; flex-wrap: wrap; gap: 6px 16px; padding: 10px 2px 0; }
+.legend-item { display: flex; align-items: center; gap: 7px; font-size: 12px; color: var(--ink-2); }
+.legend-swatch { width: 14px; height: 3px; border-radius: 2px; }
+.chart-title { font-size: 13px; font-weight: 600; margin: 2px 0 12px; }
+.chart-empty { color: var(--muted); font-size: 12.5px; padding: 30px 0; text-align: center; }
+
+/* ---------- endpoints ---------- */
+.endpoint-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(330px, 1fr)); gap: 14px; }
+.ep-card {
+  background: var(--surface); border: 1px solid var(--hairline); border-radius: 12px;
+  box-shadow: var(--shadow-panel);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  transition: border-color 120ms ease;
+}
+.ep-card:hover { border-color: var(--border); }
+.ep-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 16px 12px;
+}
+.ep-name { font-weight: 650; font-size: 14.5px; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ep-ping {
+  font-family: var(--mono); font-size: 9.5px; color: var(--muted);
+  letter-spacing: 0.06em; white-space: nowrap;
+}
+.ep-specs {
+  display: grid; grid-template-columns: max-content 1fr; gap: 5px 14px;
+  padding: 4px 16px 14px;
+  font-size: 12px;
+}
+.ep-specs dt {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--muted); padding-top: 2px;
+}
+.ep-specs dd { margin: 0; overflow-wrap: anywhere; color: var(--ink-2); }
+.ep-specs dd.mono { font-family: var(--mono); font-size: 11px; }
+.ep-notes { padding: 0 16px 12px; font-size: 12px; color: var(--muted); }
+.ep-actions {
+  display: flex; gap: 7px; align-items: center;
+  padding: 11px 16px;
+  border-top: 1px solid var(--hairline);
+  background: var(--sunken);
+  margin-top: auto;
+}
+.ep-actions .spacer { flex: 1; }
+
+/* ---------- modal & toast ---------- */
+.modal-backdrop[hidden] { display: none; }
+.modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  display: flex; align-items: flex-start; justify-content: center;
+  padding: 7vh 16px;
+  z-index: 50;
+}
+.modal {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  width: min(1240px, 100%);
+  max-height: 88vh;
+  overflow: auto;
+  padding: 22px 26px;
+  box-shadow: var(--shadow-pop);
+}
+.modal.narrow { width: min(880px, 100%); }
+.modal h2 { margin: 0 0 4px; font-size: 17px; letter-spacing: -0.01em; }
+.modal .eyebrow { margin-bottom: 2px; }
+.modal-close { float: right; }
+.detail-charts { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 16px 0; }
+@media (max-width: 800px) { .detail-charts { grid-template-columns: 1fr; } }
+.kv-list { display: grid; grid-template-columns: max-content 1fr; gap: 4px 14px; font-size: 12.5px; }
+.kv-list dt { color: var(--muted); font-family: var(--mono); font-size: 10.5px; padding-top: 1px; }
+.kv-list dd { margin: 0; overflow-wrap: anywhere; }
+
+.toast-stack { position: fixed; bottom: 18px; right: 18px; display: flex; flex-direction: column; gap: 8px; z-index: 60; }
+.toast {
+  background: var(--raised); border: 1px solid var(--border); border-radius: 10px;
+  padding: 10px 14px; font-size: 13px; max-width: 380px;
+  box-shadow: var(--shadow-pop);
+}
+.toast.err { border-color: var(--critical); }
+
+/* ---------- run target chip ---------- */
+.target-chip {
+  display: flex; align-items: center; gap: 9px;
+  background: var(--sunken);
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  padding: 6px 10px;
+  min-height: 36px;
+}
+.target-chip .mono-url {
+  font-family: var(--mono); font-size: 11.5px; color: var(--ink-2);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* ---------- model picker & export group ---------- */
+.model-row { display: flex; gap: 6px; }
+.model-row select, .model-row input { flex: 1; min-width: 0; }
+.model-row .btn { flex: none; padding-left: 9px; padding-right: 9px; }
+.export-group { display: flex; gap: 0; align-items: center; }
+.export-group .export-label {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--muted); margin-right: 8px;
+}
+.export-group .btn { border-radius: 0; margin-left: -1px; }
+.export-group .btn:first-of-type { border-radius: 8px 0 0 8px; margin-left: 0; }
+.export-group .btn:last-of-type { border-radius: 0 8px 8px 0; }

--- a/webui_static/view-compare.js
+++ b/webui_static/view-compare.js
@@ -1,0 +1,242 @@
+/* Compare view: pick saved runs, interactive metric charts, values table,
+   batch-sweep charts and the export group (ZIP / HTML / PDF). */
+
+(function () {
+  "use strict";
+
+  const {
+    state, esc, fmt, seriesColor, ctxNum, fmtDate, pageHead,
+    resultName, resultSubtitle, seriesLabel, matchesFilter, metricsForKeys,
+    ensureResults, ensureDetail, toggleCompare,
+  } = CB;
+
+  async function renderCompareView() {
+    const root = document.getElementById("view-compare");
+    root.innerHTML = `${pageHead("Bench · Analysis", "Compare",
+      "Pick up to 8 saved runs — each keeps its color while selected.")}
+    <div class="compare-layout">
+      <div class="panel">
+        <div class="panel-head"><span class="panel-title">Runs</span>
+          <button class="btn small" id="cmpClear">Clear</button></div>
+        <input type="text" id="cmpFilter" placeholder="Filter…" style="width:100%;margin-bottom:8px"
+          class="num">
+        <div class="pick-list" id="cmpPickList"></div>
+      </div>
+      <div>
+        <div class="metric-tabs" id="cmpTabs"></div>
+        <div class="chart-controls">
+          <label class="check"><input type="checkbox" id="cmpGrid" ${state.compare.grid ? "checked" : ""}> All metrics grid</label>
+          <span style="flex:1"></span>
+          ${CB.report.exportGroupHtml()}
+        </div>
+        <div id="cmpCharts"></div>
+      </div>
+    </div>`;
+
+    document.getElementById("cmpClear").addEventListener("click", () => {
+      state.compare.slots.clear();
+      renderCompareView();
+    });
+    document.getElementById("cmpFilter").addEventListener("input", renderPickList);
+    document.getElementById("cmpGrid").addEventListener("change", e => {
+      state.compare.grid = e.target.checked;
+      renderCompareCharts();
+    });
+    CB.report.wireExportGroup(root, compareEntries, "context-bench-comparison",
+      entries => entries.length === 1 ? resultName(entries[0].detail.summary) : "Benchmark comparison");
+
+    try { await ensureResults(); } catch (e) {
+      root.querySelector("#cmpPickList").innerHTML = `<div class="empty">${esc(e.message)}</div>`;
+      return;
+    }
+    renderPickList();
+    renderCompareCharts();
+  }
+
+  async function compareEntries() {
+    const entries = [];
+    for (const [folder, slot] of [...state.compare.slots.entries()].sort((a, b) => a[1] - b[1])) {
+      const detail = await ensureDetail(folder);
+      entries.push({ detail, slot, name: seriesLabel(detail.summary) });
+    }
+    return entries;
+  }
+
+  function renderPickList() {
+    const list = document.getElementById("cmpPickList");
+    if (!list) return;
+    const filterNode = document.getElementById("cmpFilter");
+    const filter = filterNode ? filterNode.value : "";
+    const rows = state.results.filter(r => !r.error && matchesFilter(r, filter));
+    if (!rows.length) {
+      list.innerHTML = `<div class="empty">No saved results.</div>`;
+      return;
+    }
+    list.innerHTML = rows.map(r => {
+      const slot = state.compare.slots.get(r.folder);
+      const on = slot != null;
+      return `<div class="pick-row ${on ? "on" : ""}" data-folder="${esc(r.folder)}" role="checkbox"
+          aria-checked="${on}" tabindex="0">
+        <span class="pick-swatch" style="${on ? `background:${seriesColor(slot)}` : ""}"></span>
+        <div style="min-width:0">
+          <div class="pick-name">${esc(resultName(r))}</div>
+          <div class="pick-sub">${esc(resultSubtitle(r))} · ${esc(fmtDate(r.timestamp))}</div>
+        </div>
+      </div>`;
+    }).join("");
+    list.querySelectorAll(".pick-row").forEach(row => {
+      const toggle = () => {
+        const folder = row.dataset.folder;
+        toggleCompare(folder, !state.compare.slots.has(folder));
+        renderPickList();
+        renderCompareCharts();
+      };
+      row.addEventListener("click", toggle);
+      row.addEventListener("keydown", e => {
+        if (e.key === " " || e.key === "Enter") { e.preventDefault(); toggle(); }
+      });
+    });
+  }
+
+  async function compareSeriesFor(metricKey) {
+    const series = [];
+    for (const [folder, slot] of state.compare.slots.entries()) {
+      let detail;
+      try { detail = await ensureDetail(folder); } catch (e) { continue; }
+      series.push({
+        name: seriesLabel(detail.summary),
+        color: seriesColor(slot),
+        slot,
+        points: detail.results.map(r => [ctxNum(r.context_size), r[metricKey]]),
+      });
+    }
+    series.sort((a, b) => a.slot - b.slot);
+    return series;
+  }
+
+  function selectedMetrics() {
+    const keys = new Set();
+    for (const folder of state.compare.slots.keys()) {
+      const summary = state.results.find(r => r.folder === folder);
+      if (summary) summary.columns.forEach(c => keys.add(c));
+    }
+    return metricsForKeys(keys);
+  }
+
+  async function renderCompareCharts() {
+    const tabs = document.getElementById("cmpTabs");
+    const container = document.getElementById("cmpCharts");
+    if (!tabs || !container) return;
+
+    if (!state.compare.slots.size) {
+      tabs.innerHTML = "";
+      container.innerHTML = `<div class="empty"><strong>Nothing selected</strong>
+        Pick runs on the left (or select them under Results).</div>`;
+      return;
+    }
+
+    const metrics = selectedMetrics();
+    if (!metrics.find(m => m.key === state.compare.metric) && metrics.length) {
+      state.compare.metric = metrics[0].key;
+    }
+    tabs.innerHTML = metrics.map(m =>
+      `<button class="metric-tab ${m.key === state.compare.metric ? "active" : ""}" data-metric="${esc(m.key)}">
+        ${esc(m.label)} <span class="unit">${esc(m.unit)}</span></button>`).join("");
+    tabs.querySelectorAll(".metric-tab").forEach(btn =>
+      btn.addEventListener("click", () => {
+        state.compare.metric = btn.dataset.metric;
+        renderCompareCharts();
+      }));
+
+    if (state.compare.grid) {
+      container.innerHTML = `<div class="chart-grid" id="cmpGridWrap"></div>${batchSectionHtml()}`;
+      const wrap = document.getElementById("cmpGridWrap");
+      for (const metric of metrics) {
+        const panel = document.createElement("div");
+        panel.className = "panel";
+        panel.innerHTML = `<div class="chart-title">${esc(metric.label)} <span class="unit">${esc(metric.unit)}</span></div><div></div>`;
+        wrap.appendChild(panel);
+        const series = await compareSeriesFor(metric.key);
+        Charts.lineChart(panel.lastElementChild, {
+          series, logX: true, height: 230, seconds: metric.seconds,
+          xLabel: "context", yLabel: metric.unit,
+        });
+      }
+    } else {
+      const metric = metrics.find(m => m.key === state.compare.metric) || metrics[0];
+      if (!metric) { container.innerHTML = `<div class="empty">No comparable metrics.</div>`; return; }
+      container.innerHTML = `<div class="panel">
+          <div class="chart-title">${esc(metric.label)} across context size <span class="unit">${esc(metric.unit)}</span></div>
+          <div id="cmpHero"></div>
+        </div>
+        <div class="panel"><div class="chart-title">Values</div><div class="tbl-wrap" id="cmpTable"></div></div>
+        ${batchSectionHtml()}`;
+      const series = await compareSeriesFor(metric.key);
+      Charts.lineChart(document.getElementById("cmpHero"), {
+        series, logX: true, height: 440, seconds: metric.seconds,
+        xLabel: "context (tokens ×1000)", yLabel: metric.unit,
+      });
+      renderCompareTable(series, metric);
+    }
+    await renderBatchCharts();
+  }
+
+  function batchSectionHtml() {
+    const hasBatch = [...state.compare.slots.keys()].some(folder => {
+      const summary = state.results.find(r => r.folder === folder);
+      return summary && summary.has_batch;
+    });
+    if (!hasBatch) return "";
+    return `<div style="margin-top:14px">
+      <p class="hint" style="margin:0 0 8px">Batch sweep = N parallel clients. »End-to-end« is generated
+        tokens ÷ total wall time (prompt phase included) — »decode« is the pure generation rate the
+        server reported, summed across clients.</p>
+      <div class="chart-grid" id="cmpBatchWrap"></div>
+    </div>`;
+  }
+
+  async function renderBatchCharts() {
+    const wrap = document.getElementById("cmpBatchWrap");
+    if (!wrap) return;
+    const entries = await compareEntries();
+    const defs = CB.report.batchChartDefs(entries);
+    const batchEntries = entries.filter(e => e.detail.batch_data && e.detail.batch_data.length);
+    wrap.innerHTML = "";
+    for (const def of defs) {
+      const unit = (def.title.match(/\[(.+)\]/) || [])[1] || "";
+      const series = batchEntries.map(e => ({
+        name: e.name,
+        color: seriesColor(e.slot),
+        points: e.detail.batch_data.map(b => [b.batch_size, b[def.field]]),
+      })).filter(s => s.points.some(p => p[1] != null && isFinite(p[1])));
+      if (!series.length) continue;
+      const panel = document.createElement("div");
+      panel.className = "panel";
+      panel.innerHTML = `<div class="chart-title">${esc(def.title.replace(/ \[.+\]$/, ""))}
+        <span class="unit">${esc(unit)}</span></div><div></div>`;
+      wrap.appendChild(panel);
+      Charts.lineChart(panel.lastElementChild, {
+        series, logX: true, height: 240,
+        xLabel: "batch size (parallel clients)", yLabel: unit,
+        xTickFormat: v => String(v),
+      });
+    }
+  }
+
+  function renderCompareTable(series, metric) {
+    const node = document.getElementById("cmpTable");
+    if (!node) return;
+    const xs = [...new Set(series.flatMap(s => s.points.map(p => p[0])))].sort((a, b) => a - b);
+    node.innerHTML = `<table class="tbl">
+      <thead><tr><th>context</th>${series.map(s =>
+        `<th><span class="legend-swatch" style="background:${s.color};display:inline-block;vertical-align:middle;margin-right:5px"></span>${esc(s.name)}</th>`).join("")}</tr></thead>
+      <tbody>${xs.map(x => `<tr><td>${esc(x)}k</td>${series.map(s => {
+        const p = s.points.find(pt => pt[0] === x && pt[1] != null);
+        return `<td>${p ? esc(fmt(p[1], { seconds: metric.seconds })) : "–"}</td>`;
+      }).join("")}</tr>`).join("")}</tbody>
+    </table>`;
+  }
+
+  CB.views.compare = renderCompareView;
+  CB.onCompareResize = renderCompareCharts;
+})();

--- a/webui_static/view-endpoints.js
+++ b/webui_static/view-endpoints.js
@@ -1,0 +1,228 @@
+/* Endpoints view: named inference targets as cards with reachability LED,
+   run stats, and the sectioned create/edit dialog with model discovery. */
+
+(function () {
+  "use strict";
+
+  const {
+    state, esc, api, toast, fmtDate, pageHead, engineById, endpointTarget,
+    ensureResults, openModal, closeModal, attachModelPicker, modelPickerHtml, render,
+  } = CB;
+
+  function endpointRunStats(ep) {
+    const runs = state.results.filter(r => !r.error && r.endpoint === ep.name);
+    if (!runs.length) return null;
+    const last = runs.map(r => r.timestamp || "").sort().pop();
+    return { count: runs.length, last };
+  }
+
+  async function renderEndpointsView() {
+    const root = document.getElementById("view-endpoints");
+    try { state.endpoints = await api("/api/endpoints"); } catch (e) { /* keep old */ }
+    try { await ensureResults(); } catch (e) { /* stats become unavailable */ }
+    root.innerHTML = `${pageHead("Bench · Targets", "Endpoints",
+      "Named inference targets. A run started against one carries its name into results and charts.",
+      `<button class="btn primary" id="epNew">New endpoint</button>`)}
+    <div class="endpoint-grid" id="epGrid"></div>`;
+    document.getElementById("epNew").addEventListener("click", () => endpointForm(null));
+
+    const grid = document.getElementById("epGrid");
+    if (!state.endpoints.length) {
+      grid.innerHTML = `<div class="empty" style="grid-column:1/-1"><strong>No endpoints yet</strong>
+        Add your servers here — e.g. »M3 Ultra · llama.cpp« or »DGX · vLLM« — and their names
+        show up in results and comparison charts.</div>`;
+      return;
+    }
+    grid.innerHTML = state.endpoints.map(ep => {
+      const engine = ep.engine ? engineById(ep.engine) : null;
+      const connection = endpointTarget(ep);
+      const stats = endpointRunStats(ep);
+      const pingable = !!connection;
+      return `
+      <div class="ep-card" data-id="${esc(ep.id)}">
+        <div class="ep-head">
+          <span class="led idle" data-f="led"></span>
+          <span class="ep-name">${esc(ep.name)}</span>
+          <span class="ep-ping" data-f="ping">${pingable ? "…" : "LOCAL"}</span>
+        </div>
+        <dl class="ep-specs">
+          ${engine ? `<dt>Engine</dt><dd>${esc(engine.label)}</dd>` : `<dt>Engine</dt><dd>any</dd>`}
+          ${connection ? `<dt>Target</dt><dd class="mono">${esc(connection)}</dd>` : ""}
+          ${ep.model ? `<dt>Model</dt><dd class="mono">${esc(ep.model)}</dd>` : ""}
+          ${ep.api_key ? `<dt>Auth</dt><dd class="mono">API key set</dd>` : ""}
+          ${stats ? `<dt>Runs</dt><dd>${stats.count} saved${stats.last ? ` · last ${esc(fmtDate(stats.last))}` : ""}</dd>` : ""}
+        </dl>
+        ${ep.notes ? `<div class="ep-notes">${esc(ep.notes)}</div>` : ""}
+        <div class="ep-actions">
+          <button class="btn small primary" data-act="bench">Benchmark</button>
+          ${stats ? `<button class="btn small" data-act="results">Results</button>` : ""}
+          <span class="spacer"></span>
+          <button class="btn small ghost" data-act="edit">Edit</button>
+          <button class="btn small ghost danger" data-act="delete" title="Delete endpoint">✕</button>
+        </div>
+      </div>`;
+    }).join("");
+
+    grid.querySelectorAll(".ep-card").forEach(card => {
+      const ep = state.endpoints.find(x => x.id === card.dataset.id);
+      card.querySelector('[data-act="bench"]').addEventListener("click", () => {
+        state.runFormEndpoint = ep.id;
+        if (ep.engine) state.runFormEngine = ep.engine;
+        location.hash = "run";
+        render();
+      });
+      const resultsBtn = card.querySelector('[data-act="results"]');
+      if (resultsBtn) resultsBtn.addEventListener("click", () => {
+        state.resultsFilter = ep.name;
+        location.hash = "results";
+      });
+      card.querySelector('[data-act="edit"]').addEventListener("click", () => endpointForm(ep));
+      card.querySelector('[data-act="delete"]').addEventListener("click", async () => {
+        if (!confirm(`Delete endpoint »${ep.name}«?`)) return;
+        try {
+          await api(`/api/endpoints/${encodeURIComponent(ep.id)}`, { method: "DELETE" });
+          renderEndpointsView();
+        } catch (e) { toast(e.message, true); }
+      });
+      pingEndpoint(ep, card);
+    });
+  }
+
+  async function pingEndpoint(ep, card) {
+    if (!endpointTarget(ep)) return;
+    const led = card.querySelector('[data-f="led"]');
+    const label = card.querySelector('[data-f="ping"]');
+    try {
+      const res = await api(`/api/endpoints/${encodeURIComponent(ep.id)}/ping`, { method: "POST" });
+      if (!card.isConnected) return;
+      if (res.ok) {
+        led.className = "led on";
+        label.textContent = `ONLINE · ${res.latency_ms} ms`;
+      } else if (res.ok === false) {
+        led.className = "led off";
+        label.textContent = "OFFLINE";
+        label.title = res.detail || "";
+      } else {
+        led.className = "led idle";
+        label.textContent = "LOCAL";
+      }
+    } catch (e) {
+      if (!card.isConnected) return;
+      led.className = "led idle";
+      label.textContent = "–";
+    }
+  }
+
+  function endpointForm(endpoint) {
+    const ep = endpoint || {};
+    const modal = openModal(`
+      <button class="btn small modal-close" data-close>Close</button>
+      <div class="eyebrow">Bench · Target</div>
+      <h2>${endpoint ? "Edit endpoint" : "New endpoint"}</h2>
+
+      <div class="section-label" style="margin-top:18px">Identity</div>
+      <div class="form-row cols-2">
+        <div class="field"><label for="epName">Name *</label>
+          <input type="text" id="epName" value="${esc(ep.name || "")}" placeholder="M3 Ultra · llama.cpp">
+          <span class="hint">Labels every run in results & comparison charts.</span></div>
+        <div class="field"><label for="epNotes">Notes</label>
+          <input type="text" id="epNotes" value="${esc(ep.notes || "")}" placeholder="e.g. speculative decoding on"></div>
+      </div>
+
+      <div class="section-label">Target</div>
+      <div class="form-row cols-2">
+        <div class="field"><label for="epEngine">Engine</label>
+          <select id="epEngine"><option value="">any (decide per run)</option>
+            ${state.meta.engines.map(e => `<option value="${esc(e.id)}" ${e.id === ep.engine ? "selected" : ""}>${esc(e.label)}</option>`).join("")}
+          </select>
+          <span class="hint" id="epEngineHint"></span></div>
+        <div class="field" id="epBaseUrlField"><label for="epBaseUrl">Base URL</label>
+          <input type="text" id="epBaseUrl" value="${esc(ep.base_url || "")}" placeholder="http://192.168.1.20:8000/v1"></div>
+      </div>
+      <div class="form-row cols-2" id="epHostRow">
+        <div class="field"><label for="epHost">Host</label>
+          <input type="text" id="epHost" value="${esc(ep.host || "")}" placeholder="192.168.1.20"></div>
+        <div class="field"><label for="epPort">Port</label>
+          <input type="number" id="epPort" value="${esc(ep.port || "")}" placeholder="8080"></div>
+      </div>
+
+      <div class="section-label">Auth & defaults</div>
+      <div class="form-row cols-2">
+        <div class="field"><label for="epApiKey">API key</label>
+          <input type="password" id="epApiKey" value="${esc(ep.api_key || "")}" autocomplete="off">
+          <span class="hint">Stored locally in webui_endpoints.json (owner-only).</span></div>
+        <div class="field"><label for="epModel">Default model</label>
+          ${modelPickerHtml("epModel", ep.model, "filled into the run form")}
+          <span class="hint" id="epModelHint">Loaded from the target server once it is reachable.</span></div>
+      </div>
+
+      <div class="btn-row" style="margin-top:18px">
+        <button class="btn primary" id="epSave">${endpoint ? "Save changes" : "Add endpoint"}</button>
+      </div>`, { narrow: true });
+
+    // show only the connection fields the chosen engine actually uses
+    const syncConnectionFields = () => {
+      const engine = engineById(modal.querySelector("#epEngine").value);
+      const kind = engine ? engine.connection : "base_url";
+      modal.querySelector("#epBaseUrlField").style.display = kind === "hostport" || kind === null ? "none" : "";
+      modal.querySelector("#epHostRow").style.display = kind === "hostport" ? "" : "none";
+      const hint = modal.querySelector("#epEngineHint");
+      if (engine && kind === null) hint.textContent = "Runs locally — no connection needed.";
+      else if (engine && kind === "hostport") hint.textContent = "Connects via host + port.";
+      else if (engine) {
+        hint.textContent = "Connects via base URL.";
+        const baseUrl = modal.querySelector("#epBaseUrl");
+        if (!baseUrl.value && engine.default_base_url) baseUrl.placeholder = engine.default_base_url;
+      } else hint.textContent = "";
+    };
+    modal.querySelector("#epEngine").addEventListener("change", syncConnectionFields);
+    syncConnectionFields();
+
+    const epConnection = () => {
+      const engineId = modal.querySelector("#epEngine").value;
+      const connection = {
+        engine: engineId,
+        base_url: modal.querySelector("#epBaseUrl").value.trim(),
+        api_key: modal.querySelector("#epApiKey").value,
+        host: modal.querySelector("#epHost").value.trim(),
+        port: modal.querySelector("#epPort").value,
+      };
+      const ollama = engineId === "ollama-api" || engineId === "ollama-cli";
+      if (!ollama && !connection.base_url && !connection.host) return null;
+      return connection;
+    };
+    const epModelPicker = attachModelPicker({
+      select: modal.querySelector("#epModelSel"),
+      input: modal.querySelector("#epModel"),
+      button: modal.querySelector("#epModelLoad"),
+      hint: modal.querySelector("#epModelHint"),
+      getConnection: epConnection,
+    });
+    for (const id of ["#epEngine", "#epBaseUrl", "#epHost", "#epPort", "#epApiKey"]) {
+      modal.querySelector(id).addEventListener("change", () => epModelPicker.load(true));
+    }
+    if (epConnection()) epModelPicker.load(true);
+
+    modal.querySelector("#epSave").addEventListener("click", async () => {
+      const payload = {
+        name: modal.querySelector("#epName").value,
+        engine: modal.querySelector("#epEngine").value,
+        base_url: modal.querySelector("#epBaseUrl").value,
+        api_key: modal.querySelector("#epApiKey").value,
+        host: modal.querySelector("#epHost").value,
+        port: modal.querySelector("#epPort").value,
+        model: epModelPicker.value(),
+        notes: modal.querySelector("#epNotes").value,
+      };
+      try {
+        if (endpoint) await api(`/api/endpoints/${encodeURIComponent(endpoint.id)}`, { method: "PUT", body: payload });
+        else await api("/api/endpoints", { body: payload });
+        closeModal();
+        renderEndpointsView();
+        toast("Endpoint saved.");
+      } catch (e) { toast(e.message, true); }
+    });
+  }
+
+  CB.views.endpoints = renderEndpointsView;
+})();

--- a/webui_static/view-results.js
+++ b/webui_static/view-results.js
@@ -1,0 +1,205 @@
+/* Results view: browse saved runs from output/, select for comparison,
+   rename/delete, and the per-run detail dialog with charts and export. */
+
+(function () {
+  "use strict";
+
+  const {
+    state, METRICS, esc, fmt, api, toast, seriesColor, ctxNum, fmtDate,
+    pageHead, resultName, resultSubtitle, seriesLabel, matchesFilter,
+    ensureResults, ensureDetail, toggleCompare, openModal,
+  } = CB;
+
+  async function renderResultsView() {
+    const root = document.getElementById("view-results");
+    root.innerHTML = `${pageHead("Bench · Archive", "Results",
+      `Every saved run from <span class="num">output/</span>. Select any set to compare.`)}
+    <div class="results-toolbar">
+      <input type="text" id="resFilter" placeholder="Filter by model, engine, label, machine…" value="${esc(state.resultsFilter)}">
+      <button class="btn small" id="resRefresh">Refresh</button>
+      <span style="flex:1"></span>
+      <button class="btn primary" id="resCompare" disabled>Compare selected</button>
+    </div>
+    <div id="resList"><div class="empty">Loading…</div></div>`;
+
+    document.getElementById("resFilter").addEventListener("input", e => {
+      state.resultsFilter = e.target.value;
+      renderResultRows();
+    });
+    document.getElementById("resRefresh").addEventListener("click", async () => {
+      await ensureResults(true);
+      renderResultRows();
+    });
+    document.getElementById("resCompare").addEventListener("click", () => {
+      location.hash = "compare";
+    });
+
+    try { await ensureResults(); } catch (e) {
+      document.getElementById("resList").innerHTML =
+        `<div class="empty">Could not load results: ${esc(e.message)}</div>`;
+      return;
+    }
+    renderResultRows();
+  }
+
+  function renderResultRows() {
+    const list = document.getElementById("resList");
+    if (!list) return;
+    const rows = state.results.filter(r => !r.error && matchesFilter(r, state.resultsFilter));
+    if (!state.results.length) {
+      list.innerHTML = `<div class="empty"><strong>No saved results yet</strong>
+        Run a benchmark — every run lands in output/ and shows up here.</div>`;
+      return;
+    }
+    list.innerHTML = rows.map(r => {
+      const checked = state.compare.slots.has(r.folder) ? "checked" : "";
+      const ctxRange = r.contexts.length ? `${r.contexts[0]}–${r.contexts[r.contexts.length - 1]}` : "–";
+      return `<div class="result-row" data-folder="${esc(r.folder)}">
+        <input type="checkbox" data-act="select" ${checked} aria-label="Select for comparison">
+        <div class="r-name">
+          <div class="r-label">${esc(resultName(r))}</div>
+          <div class="r-model">${esc(resultSubtitle(r))}</div>
+        </div>
+        <span class="tag">${esc(r.engine)}</span>
+        <span class="r-machine">${esc(r.machine || "–")}</span>
+        <span class="r-ctx">${esc(ctxRange)}</span>
+        <div class="r-peak"><span class="v">${esc(fmt(r.peak_generation_tps))}</span> <span class="unit">t/s peak</span></div>
+        <span class="r-spark">${Charts.sparkline(r.gen_series)}</span>
+        <div class="r-actions">
+          <span class="r-date">${esc(fmtDate(r.timestamp))}</span>
+          <button class="btn small" data-act="detail">Details</button>
+          <button class="btn small" data-act="rename" title="Rename label">✎</button>
+          <button class="btn small danger" data-act="delete" title="Delete result">✕</button>
+        </div>
+      </div>`;
+    }).join("") || `<div class="empty">No results match the filter.</div>`;
+
+    list.querySelectorAll(".result-row").forEach(row => {
+      const folder = row.dataset.folder;
+      row.querySelector('[data-act="select"]').addEventListener("change", e => {
+        toggleCompare(folder, e.target.checked);
+        updateCompareButton();
+      });
+      row.querySelector('[data-act="detail"]').addEventListener("click", () => openDetail(folder));
+      row.querySelector('[data-act="rename"]').addEventListener("click", () => renameResult(folder));
+      row.querySelector('[data-act="delete"]').addEventListener("click", () => deleteResult(folder));
+    });
+    updateCompareButton();
+  }
+
+  function updateCompareButton() {
+    const btn = document.getElementById("resCompare");
+    if (!btn) return;
+    const n = state.compare.slots.size;
+    btn.disabled = n < 1;
+    btn.textContent = n ? `Compare selected (${n})` : "Compare selected";
+  }
+
+  async function renameResult(folder) {
+    const summary = state.results.find(r => r.folder === folder);
+    const label = prompt("Label for this run (shown in charts):", summary ? summary.label : "");
+    if (label === null) return;
+    try {
+      await api(`/api/results/${encodeURIComponent(folder)}`, { method: "PATCH", body: { label } });
+      await ensureResults(true);
+      renderResultRows();
+    } catch (e) { toast(e.message, true); }
+  }
+
+  async function deleteResult(folder) {
+    if (!confirm(`Delete result »${folder}«?\nThis removes the folder from output/ permanently.`)) return;
+    try {
+      await api(`/api/results/${encodeURIComponent(folder)}`, { method: "DELETE" });
+      state.compare.slots.delete(folder);
+      delete state.details[folder];
+      await ensureResults(true);
+      renderResultRows();
+      toast("Result deleted.");
+    } catch (e) { toast(e.message, true); }
+  }
+
+  // ------------------------------------------------------------- detail
+
+  async function openDetail(folder) {
+    let detail;
+    try { detail = await ensureDetail(folder); } catch (e) { toast(e.message, true); return; }
+    const summary = detail.summary;
+    const rows = detail.results;
+    const cols = ["context_size", "prompt_tokens", "prompt_tps", "generation_tokens", "generation_tps",
+      "time_to_first_token", "time_per_output_token", "total_time",
+      "peak_memory_gb", "host_memory_gb", "kv_cache_gb"]
+      .filter(c => rows.some(r => r[c] != null));
+
+    // charts: the four core panels plus memory panels when the run has them
+    const chartKeys = ["generation_tps", "prompt_tps", "time_to_first_token", "total_time",
+      "peak_memory_gb", "host_memory_gb", "kv_cache_gb"]
+      .filter(key => rows.some(r => r[key] != null && isFinite(r[key])));
+    const chartPanels = chartKeys.map(key => {
+      const metric = METRICS.find(m => m.key === key) || { label: key, unit: "" };
+      return `<div><div class="chart-title">${esc(metric.label)}
+        ${metric.unit ? `<span class="unit">${esc(metric.unit)}</span>` : ""}</div>
+        <div data-chart="${esc(key)}"></div></div>`;
+    }).join("");
+
+    const hw = detail.hardware_info || {};
+    const modal = openModal(`
+      <button class="btn small modal-close" data-close>Close</button>
+      <span class="modal-close" style="margin-right:10px">${CB.report.exportGroupHtml()}</span>
+      <div class="eyebrow">${esc(summary.engine)} · ${esc(fmtDate(summary.timestamp))}</div>
+      <h2>${esc(resultName(summary))}</h2>
+      <div class="page-sub">${esc(summary.model)}${summary.hardware ? " — " + esc(summary.hardware) : ""}</div>
+      <div class="detail-charts">${chartPanels}</div>
+      <div class="tbl-wrap"><table class="tbl">
+        <thead><tr>${cols.map(c => `<th>${esc(c.replace(/_/g, " "))}</th>`).join("")}</tr></thead>
+        <tbody>${rows.map(r => `<tr>${cols.map(c =>
+          `<td>${c === "context_size" ? esc(r[c]) : esc(fmt(r[c], { seconds: /time|ttft|tpot/.test(c) }))}</td>`).join("")}</tr>`).join("")}
+        </tbody></table></div>
+      ${detail.batch_data && detail.batch_data.length ? (() => {
+        const hasDecode = detail.batch_data.some(b => b.decode_tps_total != null);
+        return `
+        <h3 style="font-size:14px;margin:18px 0 4px">Batch sweep <span class="unit">N parallel clients</span></h3>
+        <p class="hint" style="margin:0 0 8px">»E2E gen« = generated tokens ÷ total wall time (prompt
+          phase included)${hasDecode ? " — »decode« = pure generation rate, summed across clients" : ""}.</p>
+        <div class="tbl-wrap"><table class="tbl">
+          <thead><tr><th>batch</th><th>prompt t/s</th><th>e2e gen t/s</th>
+            ${hasDecode ? "<th>decode t/s</th><th>decode / client</th>" : ""}</tr></thead>
+          <tbody>${detail.batch_data.map(b => `<tr><td>${esc(b.batch_size)}</td>
+            <td>${esc(fmt(b.prompt_tps))}</td><td>${esc(fmt(b.generation_tps))}</td>
+            ${hasDecode ? `<td>${esc(fmt(b.decode_tps_total))}</td><td>${esc(fmt(b.decode_tps_per_client))}</td>` : ""}
+          </tr>`).join("")}</tbody>
+        </table></div>`;
+      })() : ""}
+      ${detail.perplexity_data ? `<p style="font-size:12.5px;color:var(--ink-2)">
+        Perplexity: <span class="num">${esc(fmt(detail.perplexity_data.perplexity))}</span>
+        ± ${esc(fmt(detail.perplexity_data.std_error))} (${esc(detail.perplexity_data.dataset || "")})</p>` : ""}
+      <details class="advanced"><summary>Hardware & files</summary><div>
+        <dl class="kv-list">
+          ${Object.entries(hw).map(([k, v]) => `<dt>${esc(k)}</dt><dd>${esc(String(v))}</dd>`).join("")}
+        </dl>
+        <p style="font-size:12px">${detail.files.map(f =>
+          `<a href="/output/${encodeURIComponent(folder)}/${encodeURIComponent(f)}" target="_blank" style="color:var(--accent)">${esc(f)}</a>`
+        ).join(" · ")}</p>
+      </div></details>`);
+
+    CB.report.wireExportGroup(modal,
+      async () => [{ detail, slot: 0, name: seriesLabel(summary) }],
+      "context-bench-run",
+      () => seriesLabel(summary));
+
+    const color = seriesColor(0);
+    for (const key of chartKeys) {
+      const node = modal.querySelector(`[data-chart="${key}"]`);
+      const metric = METRICS.find(m => m.key === key) || {};
+      Charts.lineChart(node, {
+        series: [{
+          name: seriesLabel(summary), color,
+          points: rows.map(r => [ctxNum(r.context_size), r[key]]),
+        }],
+        logX: true, height: 190, seconds: metric.seconds,
+        xLabel: "context", yLabel: metric.unit || "", legend: false,
+      });
+    }
+  }
+
+  CB.views.results = renderResultsView;
+})();

--- a/webui_static/view-run.js
+++ b/webui_static/view-run.js
@@ -1,0 +1,406 @@
+/* Run view: endpoint-driven benchmark launcher plus the live run list
+   (status LEDs, live readout, context progress lane, streaming log). */
+
+(function () {
+  "use strict";
+
+  const {
+    state, esc, fmt, api, toast, fmtDuration, pageHead, engineById, endpointTarget,
+    attachModelPicker, modelPickerHtml, currentView,
+  } = CB;
+
+  // connection values for the run: from the endpoint, else the manual fields
+  function readConnection(ep) {
+    const connection = {};
+    if (ep) {
+      connection.base_url = ep.base_url || "";
+      connection.api_key = ep.api_key || "";
+      connection.host = ep.host || "";
+      connection.port = ep.port || "";
+    } else {
+      const field = id => document.getElementById(id);
+      if (field("rfBaseUrl")) connection.base_url = field("rfBaseUrl").value.trim();
+      if (field("rfApiKey")) connection.api_key = field("rfApiKey").value;
+      if (field("rfHost")) connection.host = field("rfHost").value.trim();
+      if (field("rfPort")) connection.port = field("rfPort").value;
+    }
+    return connection;
+  }
+
+  function renderRunView() {
+    const root = document.getElementById("view-run");
+    const engines = state.meta.engines;
+
+    // endpoint-first: the endpoint carries engine + connection + default model
+    const ep = state.endpoints.find(x => x.id === state.runFormEndpoint) || null;
+    if (ep && ep.engine && engineById(ep.engine)) state.runFormEngine = ep.engine;
+    if (!state.runFormEngine || !engineById(state.runFormEngine)) {
+      state.runFormEngine = (engines.find(e => e.available) || engines[0]).id;
+    }
+    const engine = engineById(state.runFormEngine);
+    const engineLocked = !!(ep && ep.engine);
+    const manual = !ep;
+    const defaultCtx = engine.default_contexts.split(",").map(s => s.trim());
+    const target = ep ? (endpointTarget(ep) || "local") : "";
+
+    root.innerHTML = `
+      ${pageHead("Bench · Launch", "Run sweep",
+        "Prompt processing & generation speed across context sizes.")}
+      <div class="grid-2">
+        <div class="panel">
+          <div class="form-row cols-2">
+            <div class="field">
+              <label for="rfEndpoint">Endpoint</label>
+              <select id="rfEndpoint">
+                <option value="">— manual / local —</option>
+                ${state.endpoints.map(x => `<option value="${esc(x.id)}" ${ep && ep.id === x.id ? "selected" : ""}>${esc(x.name)}</option>`).join("")}
+              </select>
+              <span class="hint">${state.endpoints.length
+                ? "Engine & connection come from the endpoint; its name labels the run."
+                : `No endpoints yet — add them under <a href="#endpoints" style="color:var(--accent)">Endpoints</a>.`}</span>
+            </div>
+            ${engineLocked ? `
+            <div class="field">
+              <label>Target</label>
+              <div class="target-chip">
+                <span class="tag">${esc(engine.label)}</span>
+                <span class="mono-url">${esc(target)}</span>
+              </div>
+              <span class="hint">${esc(engine.description)}</span>
+            </div>` : `
+            <div class="field">
+              <label for="rfEngine">Engine</label>
+              <select id="rfEngine">
+                ${engines.map(e => `<option value="${esc(e.id)}" ${e.id === engine.id ? "selected" : ""}
+                  ${e.available ? "" : "disabled"}>${esc(e.label)}${e.available ? "" : " — needs Apple Silicon"}</option>`).join("")}
+              </select>
+              <span class="hint">${esc(engine.description)}</span>
+            </div>`}
+          </div>
+          <div class="form-row cols-2">
+            <div class="field">
+              <label for="rfModel">Model ${engine.model === "auto" ? "(optional, auto-detected)" : ""}</label>
+              ${modelPickerHtml("rfModel", ep ? ep.model : "", engine.example)}
+              <span class="hint" id="rfModelHint"></span>
+            </div>
+            <div class="field">
+              <label for="rfLabel">Run label</label>
+              <input type="text" id="rfLabel" value="${esc(ep ? ep.name : "")}" placeholder="e.g. M3 Ultra · speculative on">
+              <span class="hint">Shown in results & comparison charts.</span>
+            </div>
+          </div>
+          ${manual ? renderConnectionFields(engine) : ""}
+          ${!engine.available ? `<p class="hint" style="color:var(--critical)">
+            This engine needs Apple Silicon (MLX) and is disabled on this machine.</p>` : ""}
+          <div class="field" style="margin-bottom:12px">
+            <label>Context sizes <span class="unit">tokens ×1000</span></label>
+            <div class="ctx-chips" id="rfContexts">
+              ${state.meta.context_files.map(c => `
+                <label class="ctx-chip"><input type="checkbox" value="${esc(c.name.replace(/k$/, ""))}"
+                  ${defaultCtx.includes(String(c.name.replace(/k$/, ""))) ? "checked" : ""}>
+                  <span>${esc(c.name)}</span></label>`).join("")}
+            </div>
+          </div>
+          <div class="form-row cols-4">
+            <div class="field"><label for="rfMaxTokens">Max tokens</label>
+              <input type="number" id="rfMaxTokens" value="128" min="1"></div>
+            <div class="field"><label for="rfRuns">Runs / context</label>
+              <input type="number" id="rfRuns" value="2" min="1"></div>
+            <div class="field"><label for="rfTimeout">Timeout <span class="unit">s</span></label>
+              <input type="number" id="rfTimeout" value="3600" min="10"></div>
+            <div class="field"><label>&nbsp;</label>
+              <label class="check"><input type="checkbox" id="rfSaveResponses"> Save responses</label></div>
+          </div>
+          ${engine.cold_prefill ? `<label class="check" style="margin-bottom:4px">
+            <input type="checkbox" id="rfColdPrefill" checked> Cold prefill (clear cache between contexts)</label>` : ""}
+          ${renderEngineOptions(engine)}
+          <details class="advanced">
+            <summary>Extra CLI arguments</summary>
+            <div class="field"><input type="text" id="rfExtraArgs" placeholder="--some-flag value"></div>
+          </details>
+          <div class="btn-row" style="margin-top:16px">
+            <button class="btn primary" id="rfStart" ${engine.available ? "" : "disabled"}>Start benchmark</button>
+          </div>
+        </div>
+        <div>
+          <div class="panel-head" style="margin-bottom:8px">
+            <span class="eyebrow">Live · Active & recent runs</span>
+          </div>
+          <div id="runList" data-kind="benchmark"></div>
+        </div>
+      </div>`;
+
+    document.getElementById("rfEndpoint").addEventListener("change", e => {
+      state.runFormEndpoint = e.target.value;
+      renderRunView();
+    });
+    const engineSelect = document.getElementById("rfEngine");
+    if (engineSelect) engineSelect.addEventListener("change", e => {
+      state.runFormEngine = e.target.value;
+      renderRunView();
+    });
+
+    // like readConnection, but with the engine defaults filled in so model
+    // discovery can hit the server before the user typed anything
+    const runConnection = () => {
+      const connection = { engine: engine.id, ...readConnection(ep) };
+      if (!ep) {
+        if ("base_url" in connection) connection.base_url = connection.base_url || engine.default_base_url || "";
+        if ("host" in connection) connection.host = connection.host || "localhost";
+      }
+      const ollama = engine.id === "ollama-api" || engine.id === "ollama-cli";
+      if (!ollama && !connection.base_url && !connection.host) return null;
+      return connection;
+    };
+    state.runModelPicker = attachModelPicker({
+      select: document.getElementById("rfModelSel"),
+      input: document.getElementById("rfModel"),
+      button: document.getElementById("rfModelLoad"),
+      hint: document.getElementById("rfModelHint"),
+      getConnection: runConnection,
+    });
+    for (const id of ["rfBaseUrl", "rfHost", "rfPort", "rfApiKey"]) {
+      const node = document.getElementById(id);
+      if (node) node.addEventListener("change", () => state.runModelPicker.load(true));
+    }
+    if (runConnection()) {
+      state.runModelPicker.load(true).then(() => {
+        if (ep && ep.model) state.runModelPicker.set(ep.model);
+      });
+    }
+    document.getElementById("rfStart").addEventListener("click", startRun);
+
+    renderRunList();
+    startRunsPolling();
+  }
+
+  function renderConnectionFields(engine) {
+    if (engine.connection === "base_url") {
+      return `<div class="form-row cols-2">
+        <div class="field"><label for="rfBaseUrl">Base URL</label>
+          <input type="text" id="rfBaseUrl" placeholder="${esc(engine.default_base_url || "http://host:port/v1")}"></div>
+        <div class="field"><label for="rfApiKey">API key (optional)</label>
+          <input type="password" id="rfApiKey" autocomplete="off"></div>
+      </div>`;
+    }
+    if (engine.connection === "hostport") {
+      return `<div class="form-row cols-2">
+        <div class="field"><label for="rfHost">Host</label>
+          <input type="text" id="rfHost" value="localhost"></div>
+        <div class="field"><label for="rfPort">Port</label>
+          <input type="number" id="rfPort" value="8080"></div>
+      </div>`;
+    }
+    return "";
+  }
+
+  function renderEngineOptions(engine) {
+    if (!engine.options.length) return "";
+    const fields = engine.options.map(opt => {
+      const id = "opt_" + opt.key;
+      if (opt.type === "flag" || opt.type === "invflag" || opt.type === "optbool") {
+        return `<label class="check"><input type="checkbox" id="${id}" data-optkey="${esc(opt.key)}"
+          ${opt.default ? "checked" : ""}> ${esc(opt.label)}</label>`;
+      }
+      if (opt.type === "choice") {
+        return `<div class="field"><label for="${id}">${esc(opt.label)}</label>
+          <select id="${id}" data-optkey="${esc(opt.key)}">
+            ${opt.choices.map(c => `<option value="${esc(c)}" ${c === opt.default ? "selected" : ""}>${esc(c || "default")}</option>`).join("")}
+          </select></div>`;
+      }
+      const value = opt.default == null ? "" : opt.default;
+      const type = (opt.type === "int" || opt.type === "float") ? "number" : "text";
+      const step = opt.type === "float" ? ` step="any"` : "";
+      return `<div class="field"><label for="${id}">${esc(opt.label)}${opt.required ? " *" : ""}</label>
+        <input type="${type}"${step} id="${id}" data-optkey="${esc(opt.key)}" value="${esc(value)}"
+          ${opt.help ? `title="${esc(opt.help)}"` : ""}></div>`;
+    });
+    return `<details class="advanced" ${engine.options.some(o => o.required) ? "open" : ""}>
+      <summary>Engine options</summary>
+      <div><div class="form-row cols-3">${fields.join("")}</div></div>
+    </details>`;
+  }
+
+  async function startRun() {
+    const engine = engineById(state.runFormEngine);
+    const ep = state.endpoints.find(x => x.id === state.runFormEndpoint) || null;
+    const contexts = [...document.querySelectorAll("#rfContexts input:checked")].map(i => i.value);
+    if (!contexts.length) { toast("Select at least one context size.", true); return; }
+
+    const options = {};
+    document.querySelectorAll("#view-run [data-optkey]").forEach(node => {
+      const key = node.dataset.optkey;
+      if (node.type === "checkbox") options[key] = node.checked;
+      else if (node.value !== "") options[key] = node.value;
+    });
+
+    const connection = readConnection(ep);
+    const cold = document.getElementById("rfColdPrefill");
+    const payload = {
+      engine: engine.id,
+      model: state.runModelPicker ? state.runModelPicker.value() : document.getElementById("rfModel").value,
+      label: document.getElementById("rfLabel").value,
+      endpoint_id: ep ? ep.id : null,
+      contexts: contexts.join(","),
+      max_tokens: document.getElementById("rfMaxTokens").value,
+      runs: document.getElementById("rfRuns").value,
+      timeout: document.getElementById("rfTimeout").value,
+      save_responses: document.getElementById("rfSaveResponses").checked,
+      cold_prefill: cold ? cold.checked : undefined,
+      connection,
+      options,
+      extra_args: document.getElementById("rfExtraArgs").value,
+    };
+    try {
+      const run = await api("/api/runs", { body: payload });
+      toast(`Benchmark started: ${run.engine} · ${run.model}`);
+      renderRunList();
+      startRunsPolling();
+    } catch (err) {
+      toast("Start failed: " + err.message, true);
+    }
+  }
+
+  // ------------------------------------------------- run list & polling
+
+  async function renderRunList() {
+    const container = document.querySelector(".view:not([hidden]) #runList");
+    if (!container) return;
+    let runs;
+    try { runs = await api("/api/runs"); } catch (e) { return; }
+    const kind = container.dataset.kind;
+    if (kind) runs = runs.filter(r => r.kind === kind);
+
+    if (!runs.length) {
+      container.innerHTML = kind === "ctxgen"
+        ? ""
+        : `<div class="empty"><strong>No runs yet this session</strong>
+            Configure a sweep on the left and hit »Start benchmark«.</div>`;
+      return;
+    }
+
+    const anyActive = runs.some(r => r.status === "running" || r.status === "starting");
+    // iterate oldest-first so prepend leaves the newest run on top
+    for (const run of runs.slice().reverse()) {
+      let card = container.querySelector(`[data-run="${run.id}"]`);
+      if (!card) card = createRunCard(container, run);
+      updateRunCard(card, run);
+    }
+    if (anyActive) startRunsPolling(); else stopRunsPolling();
+  }
+
+  function createRunCard(container, run) {
+    const card = document.createElement("div");
+    card.className = "run-card";
+    card.dataset.run = run.id;
+    container.prepend(card);
+    card.innerHTML = `
+      <div class="run-card-head">
+        <span class="led"></span>
+        <div>
+          <div class="run-card-title"></div>
+          <div class="run-card-meta"></div>
+        </div>
+        <div class="run-card-spacer"></div>
+        <button class="btn small" data-act="toggle-log">Log</button>
+        <button class="btn small danger" data-act="stop">Stop</button>
+      </div>
+      <div class="readout">
+        <div class="readout-cell"><span class="eyebrow">Prompt</span>
+          <span class="readout-value" data-f="prompt">–<span class="unit"> t/s</span></span></div>
+        <div class="readout-cell"><span class="eyebrow">Generation</span>
+          <span class="readout-value" data-f="gen">–<span class="unit"> t/s</span></span></div>
+        <div class="readout-cell"><span class="eyebrow">TTFT</span>
+          <span class="readout-value" data-f="ttft">–<span class="unit"> s</span></span></div>
+        <div class="readout-cell"><span class="eyebrow">Elapsed</span>
+          <span class="readout-value" data-f="elapsed">–</span></div>
+      </div>
+      <div class="ctx-lane" data-f="lane"></div>
+      <pre class="console" data-f="log" hidden></pre>`;
+    card.querySelector('[data-act="stop"]').addEventListener("click", async () => {
+      try { await api(`/api/runs/${run.id}/stop`, { method: "POST" }); } catch (e) { toast(e.message, true); }
+    });
+    card.querySelector('[data-act="toggle-log"]').addEventListener("click", () => {
+      const log = card.querySelector('[data-f="log"]');
+      log.hidden = !log.hidden;
+      if (!log.hidden) log.scrollTop = log.scrollHeight;
+    });
+    const cached = state.runLogs[run.id];
+    if (cached && cached.text) card.querySelector('[data-f="log"]').textContent = cached.text;
+    return card;
+  }
+
+  async function updateRunCard(card, run) {
+    const dot = card.querySelector(".led");
+    dot.className = "led " + run.status;
+    card.querySelector(".run-card-title").textContent =
+      (run.label ? run.label + " — " : "") + run.engine + " · " + run.model;
+    const statusText = { starting: "starting", running: "running", done: "completed",
+      failed: "failed (exit " + run.returncode + ")", stopped: "stopped" }[run.status] || run.status;
+    card.querySelector(".run-card-meta").textContent =
+      statusText + (run.error ? " — " + run.error : "");
+    card.querySelector('[data-f="elapsed"]').textContent = fmtDuration(run.elapsed);
+    if (run.live.prompt_tps != null)
+      card.querySelector('[data-f="prompt"]').innerHTML = `${esc(fmt(run.live.prompt_tps))}<span class="unit"> t/s</span>`;
+    if (run.live.generation_tps != null)
+      card.querySelector('[data-f="gen"]').innerHTML = `${esc(fmt(run.live.generation_tps))}<span class="unit"> t/s</span>`;
+    if (run.live.ttft != null)
+      card.querySelector('[data-f="ttft"]').innerHTML = `${esc(run.live.ttft.toFixed(2))}<span class="unit"> s</span>`;
+
+    const lane = card.querySelector('[data-f="lane"]');
+    if (run.contexts.length) {
+      lane.innerHTML = run.contexts.map((ctx, i) => {
+        const name = /k$/.test(ctx) ? ctx : ctx + "k";
+        let cls = "";
+        if (run.status === "done" || i < run.contexts_done) cls = "done";
+        else if (run.current_context && run.current_context.replace(/k$/, "") === String(ctx).replace(/k$/, "")) cls = "active";
+        return `<span class="ctx-step ${cls}">${esc(name)}</span>`;
+      }).join("");
+    } else lane.hidden = true;
+
+    const stopBtn = card.querySelector('[data-act="stop"]');
+    stopBtn.disabled = !(run.status === "running" || run.status === "starting");
+
+    // incremental log fetch — the child runs unbuffered, so this streams live
+    const logNode = card.querySelector('[data-f="log"]');
+    const cache = state.runLogs[run.id] || (state.runLogs[run.id] = { offset: 0, text: "" });
+    if (cache.offset < run.log_length) {
+      try {
+        const data = await api(`/api/runs/${run.id}?offset=${cache.offset}`);
+        cache.offset = data.next_offset;
+        cache.text += (cache.text ? "\n" : "") + data.log.join("\n");
+        const atBottom = logNode.scrollHeight - logNode.scrollTop - logNode.clientHeight < 40;
+        logNode.textContent = cache.text;
+        if (atBottom) logNode.scrollTop = logNode.scrollHeight;
+      } catch (e) { /* transient */ }
+    }
+    if ((run.status === "done") && !cache.notified) {
+      cache.notified = true;
+      state.results = [];   // invalidate results cache
+      if (run.result_folders && run.result_folders.length) {
+        toast("Run finished — results saved: " + run.result_folders.join(", "));
+      }
+      if (run.kind === "ctxgen") {
+        // new {size}k.txt files may exist now — refresh chips
+        try {
+          state.meta = await api("/api/meta");
+          if (currentView() === "tools" && CB.views.tools) CB.views.tools();
+        } catch (e) { /* next reload picks it up */ }
+      }
+    }
+  }
+
+  function startRunsPolling() {
+    if (state.runsPollTimer) return;
+    state.runsPollTimer = setInterval(() => {
+      if (currentView() === "run" || currentView() === "tools") renderRunList();
+    }, 1200);
+  }
+  function stopRunsPolling() {
+    clearInterval(state.runsPollTimer);
+    state.runsPollTimer = null;
+  }
+
+  CB.views.run = renderRunView;
+  CB.runs = { renderRunList, startRunsPolling };
+})();

--- a/webui_static/view-tools.js
+++ b/webui_static/view-tools.js
@@ -1,0 +1,82 @@
+/* Tools view: token-precise context-file generation, including uploading
+   custom .txt source texts; generator progress shows inline below. */
+
+(function () {
+  "use strict";
+
+  const { state, esc, api, toast, pageHead } = CB;
+
+  function renderToolsView() {
+    const root = document.getElementById("view-tools");
+    root.innerHTML = `${pageHead("Bench · Utilities", "Tools",
+      "Context-file generation and housekeeping.")}
+    <div style="max-width:880px">
+      <div class="panel">
+        <div class="panel-title" style="margin-bottom:10px">Generate context files</div>
+        <p style="font-size:12.5px;color:var(--ink-2);margin-top:0">Creates token-precise
+          <span class="num">{size}k.txt</span> files from a source text (tiktoken).</p>
+        <div class="form-row cols-2">
+          <div class="field"><label>Source text</label>
+            <div class="model-row">
+              <select id="cgSource">${(state.meta.source_files || []).map(f =>
+                `<option>${esc(f)}</option>`).join("")}</select>
+              <button type="button" class="btn small" id="cgUpload" title="Upload your own .txt source">Upload…</button>
+              <input type="file" id="cgUploadFile" accept=".txt,text/plain" hidden>
+            </div>
+            <span class="hint">Any .txt works — long books give the best token variety.</span></div>
+          <div class="field"><label>Sizes <span class="unit">×1000 tokens</span></label>
+            <input type="text" id="cgSizes" value="2,4,8,16,32,64,128"></div>
+        </div>
+        <button class="btn primary" id="cgRun">Generate</button>
+        <div style="margin-top:16px">
+          <div class="eyebrow" style="margin-bottom:6px">Available context files</div>
+          <div class="ctx-chips">${state.meta.context_files.map(c =>
+            `<span class="ctx-chip"><span>${esc(c.name)}</span></span>`).join("") || "none"}</div>
+        </div>
+      </div>
+      <div id="runList" data-kind="ctxgen" style="margin-top:16px"></div>
+    </div>`;
+
+    document.getElementById("cgUpload").addEventListener("click", () =>
+      document.getElementById("cgUploadFile").click());
+    document.getElementById("cgUploadFile").addEventListener("change", async e => {
+      const file = e.target.files[0];
+      if (!file) return;
+      try {
+        const body = await file.arrayBuffer();
+        const res = await fetch(`/api/source-files?name=${encodeURIComponent(file.name)}`, {
+          method: "POST", body,
+        });
+        if (!res.ok) {
+          let detail = res.statusText;
+          try { detail = (await res.json()).detail || detail; } catch (err) { /* ignore */ }
+          throw new Error(detail);
+        }
+        const saved = await res.json();
+        toast(`Uploaded ${saved.name}.`);
+        state.meta = await api("/api/meta");
+        renderToolsView();
+        document.getElementById("cgSource").value = saved.name;
+      } catch (err) {
+        toast("Upload failed: " + err.message, true);
+      }
+    });
+
+    document.getElementById("cgRun").addEventListener("click", async () => {
+      try {
+        await api("/api/context-files", {
+          body: {
+            source: document.getElementById("cgSource").value,
+            sizes: document.getElementById("cgSizes").value,
+          },
+        });
+        toast("Context file generation started.");
+        CB.runs.renderRunList();
+        CB.runs.startRunsPolling();
+      } catch (e) { toast(e.message, true); }
+    });
+    CB.runs.renderRunList();
+  }
+
+  CB.views.tools = renderToolsView;
+})();


### PR DESCRIPTION
## Summary

This PR adds a full web UI to the toolkit as a new `benchmark-webui` entry point (FastAPI + dependency-free vanilla JS, served on `http://127.0.0.1:8321`). Everything the CLI can do is now available in the browser — launching sweeps with live progress, managing named endpoints, browsing saved results, and building interactive comparisons across any set of runs.

```bash
uv sync
uv run benchmark-webui            # opens http://127.0.0.1:8321
uv run benchmark-webui --host 0.0.0.0 --port 9000 --no-open
```

## What's included

### Run view — launch sweeps with live feedback
- Endpoint-driven launcher: pick a configured endpoint and the engine, connection, API key and default model come from it (a manual/local mode remains as fallback, e.g. for local MLX runs).
- The model field is a dropdown populated live from the target server (OpenAI-compatible `/v1/models`, Ollama `/api/tags`), with manual entry as fallback.
- Live run cards: status LED, streaming prompt/generation TPS + TTFT readout, per-context progress lane and a collapsible log console. Children run with `PYTHONUNBUFFERED=1` so output actually streams line-by-line instead of arriving in 8 KB bursts.
- All engine-specific CLI options are exposed per engine (KV bits, batch sweep parameters, sampling, …) plus a free-text field for extra arguments.
- MLX-local engines (`mlx`, `mlx-vlm`, `mlx-distributed`, `paroquant`) are automatically disabled on non-Apple-Silicon hosts.

### Endpoints — named inference targets
- CRUD for named targets ("M3 Ultra · llama.cpp", "DGX · vLLM") with engine, base URL / host+port, API key and default model; the form only shows the connection fields the chosen engine actually uses.
- Cards show a live reachability LED (online + latency / offline), the run count against that endpoint, and jump-off buttons to benchmark or filter results.
- The endpoint name labels every run it starts (written into a `webui_run.json` file inside the result folder) and shows up in results and every chart legend.
- Stored in `webui_endpoints.json` (gitignored, written `0600`; API keys are redacted from displayed commands).

### Results & Compare
- Results: every folder in `output/` with sparklines, peak TPS, machine and date; a detail dialog with per-metric charts (including memory when available), the full values table, hardware info and file links; rename/delete built in.
- Compare: select up to 8 runs (stable per-run colors), metric tabs for generation/prompt TPS, TTFT, TPOT, total time, tokenizer-free bytes/s, peak memory, host RAM and KV cache — tabs appear only when the data exists. Values table, an all-metrics grid mode, and batch-sweep charts.
- Charts are hand-rolled responsive SVGs (log₂ context axis, crosshair tooltips, dark/light theming) instead of static matplotlib PNGs.
- Chart series are labelled `label · model`, so multiple runs against the same endpoint stay distinguishable everywhere.

### Exports (all client-side, no extra dependencies)
- **ZIP** — one compact overview PNG (header + legend + all charts in a grid) plus `results.csv` (long format), `batch_results.csv` and aligned plain-text comparison tables.
- **HTML** — a self-contained interactive report: dark/light toggle (dark default), clickable/hoverable data points with value tooltips, run table and per-metric tables. ~90 KB since charts ship as SVG.
- **PDF** — a print-friendly report (cover with run list and hardware, one chart per page, monospace data tables) generated by a minimal hand-rolled PDF writer.
- Available for comparisons and for single runs from the detail dialog.

### Tools
- Context-file generation from the UI, including uploading your own `.txt` source texts; generator progress streams inline and the context-size chips refresh automatically.

### `openai_benchmark.py` improvements
- The batch sweep now also records the **pure decode rate** from server usage (`decode_tps_total`, `decode_tps_per_client`) next to the existing end-to-end number — the e2e value includes the prompt phase and was easy to misread as the generation speed. Labels across the UI/exports now say "end-to-end" vs "decode" explicitly.
- When the endpoint runs on the same machine, the client samples **host RAM/VRAM** (peak system memory, which on Apple Silicon is the unified GPU memory) during each request and stores it as `host_memory_gb` — surfaced as its own metric in charts, comparisons and all exports.

## Architecture

- Backend split into flat modules per the repo convention: `webui.py` (routes), `webui_common.py` (paths), `webui_engines.py` (engine catalog + CLI command construction), `webui_runs.py` (subprocess run manager).
- Frontend in `webui_static/`: `core.js` (state/router/helpers on `window.CB`), `charts.js`, `export.js` (ZIP/CSV/HTML/PDF builders), `report.js` (export pipeline), one `view-*.js` per view, `app.js` (bootstrap). No frameworks, no CDN, works fully offline.
- New dependencies: `fastapi`, `uvicorn`.
- README and CLAUDE.md updated accordingly.

## Testing

- Exercised end-to-end against live OMLX/OpenAI-compatible servers on Apple Silicon (M4 Pro): runs stream live, results/comparisons render, all three export formats verified by unpacking/rendering the artifacts.
- Full-view regression sweeps via headless Chromium after each milestone (all views render without console errors; downloads verified).
- Failure paths covered: unreachable endpoints fail cleanly with the exit code and log visible; model discovery falls back to manual entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)