### PR TITLE
webui: sort engines alphabetically + register unsloth

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -43,7 +43,7 @@ from webui_common import (
     STATIC_DIR,
     is_apple_silicon,
 )
-from webui_engines import build_command, engine_available, get_engine_catalog
+from webui_engines import build_command, cached_mlx_models, engine_available, get_engine_catalog
 from webui_runs import RunManager
 
 run_manager = RunManager()
@@ -274,6 +274,14 @@ def api_models(payload: dict):
         return {"models": models}
     except Exception as exc:
         return {"models": [], "detail": f"{exc.__class__.__name__}: {exc}"}
+
+
+@app.get("/api/cached-models")
+def api_cached_models(engine: str = ""):
+    """Local HF-cache models for an engine that has no server (e.g. MLX)."""
+    if engine == "mlx":
+        return {"models": cached_mlx_models()}
+    return {"models": []}
 
 
 @app.post("/api/endpoints/{endpoint_id}/ping")

--- a/webui_engines.py
+++ b/webui_engines.py
@@ -1,5 +1,6 @@
 """Engine catalog and benchmark-command construction for the web UI."""
 
+import json
 import sys
 
 from fastapi import HTTPException
@@ -507,6 +508,54 @@ def engine_available(info: dict) -> bool:
     if info.get("local_mlx") and not is_apple_silicon():
         return False
     return True
+
+
+def cached_mlx_models() -> list:
+    """Local HF-cache models the MLX (mlx_lm) engine can load.
+
+    Walks the cache via huggingface_hub (honors HF_HOME) and keeps only
+    MLX-format text models: a tokenizer + config.json, no GGUF weights, and
+    either an MLX ``quantization`` block in config.json or an ``mlx`` marker in
+    the repo id. Vanilla HF transformers repos (Qwen3-0.6B, gpt2, gemma, ...)
+    are excluded because mlx_lm needs MLX-converted weights.
+    """
+    # ponytail: heuristic, not a load attempt. Name markers drop unambiguous
+    # non-text MLX repos (whisper/TTS/flux/multimodal) that mlx_lm can't load;
+    # mlx-vlm has its own engine. Upgrade to probing mlx_lm.load if needed.
+    try:
+        from huggingface_hub import scan_cache_dir
+    except ImportError:
+        return []
+
+    non_text = ("whisper", "tts", "asr", "flux", "mflux", "multimodal")
+    models = []
+    for repo in scan_cache_dir().repos:
+        if str(repo.repo_type) != "model":
+            continue
+        repo_lower = repo.repo_id.lower()
+        if any(m in repo_lower for m in non_text):
+            continue
+        names = set()
+        config_path = None
+        for rev in repo.revisions:
+            for f in rev.files:
+                names.add(f.file_name)
+                if f.file_name == "config.json" and config_path is None:
+                    config_path = getattr(f, "file_path", None)
+        if "config.json" not in names or any(n.lower().endswith(".gguf") for n in names):
+            continue
+        if not any(n in names for n in ("tokenizer.json", "tokenizer_config.json")):
+            continue
+        is_mlx = "mlx" in repo_lower
+        if not is_mlx and config_path:
+            try:
+                with open(config_path) as fh:
+                    is_mlx = isinstance(json.load(fh).get("quantization"), dict)
+            except Exception:
+                pass
+        if is_mlx:
+            models.append(repo.repo_id)
+    return sorted(models)
 
 
 # ---------------------------------------------------------------------------

--- a/webui_engines.py
+++ b/webui_engines.py
@@ -65,7 +65,7 @@ def _request_model_opt() -> dict:
 
 def get_engine_catalog() -> dict:
     """Full engine catalog with everything the UI needs to build run forms."""
-    return {
+    catalog = {
         "ollama-api": {
             "label": "Ollama API",
             "script": "ollama_api_benchmark.py",
@@ -162,6 +162,19 @@ def get_engine_catalog() -> dict:
             "cold_prefill": True,
             "local_mlx": False,
             "options": _batch_opts(),
+        },
+        "unsloth": {
+            "label": "Unsloth",
+            "script": "unsloth_benchmark.py",
+            "tag": "unsloth",
+            "description": "Unsloth Studio local server (OpenAI-compatible + server timings)",
+            "example": "unsloth/Qwen3.6-35B-A3B-GGUF",
+            "model": "auto",
+            "connection": "base_url",
+            "default_base_url": "http://127.0.0.1:8888/v1",
+            "cold_prefill": True,
+            "local_mlx": False,
+            "options": [],
         },
         "vllm": {
             "label": "vLLM",
@@ -487,6 +500,7 @@ def get_engine_catalog() -> dict:
             ],
         },
     }
+    return dict(sorted(catalog.items()))
 
 
 def engine_available(info: dict) -> bool:

--- a/webui_static/core.js
+++ b/webui_static/core.js
@@ -247,14 +247,14 @@
   // A text input that upgrades to a dropdown once the target server's
   // model list was fetched (OpenAI /v1/models or the local Ollama daemon).
 
-  function attachModelPicker({ select, input, button, hint, getConnection }) {
+  function attachModelPicker({ select, input, button, hint, getConnection, localEngine }) {
     function show(asSelect) {
       select.hidden = !asSelect;
       input.hidden = asSelect;
     }
     async function load(auto) {
       const connection = getConnection();
-      if (!connection) {
+      if (!connection && !localEngine) {
         show(false);
         if (!auto) toast("No connection configured — enter the model manually.", true);
         return;
@@ -263,7 +263,9 @@
       const original = button.textContent;
       button.textContent = "…";
       try {
-        const res = await api("/api/models", { body: connection });
+        const res = connection
+          ? await api("/api/models", { body: connection })
+          : await api(`/api/cached-models?engine=${encodeURIComponent(localEngine)}`);
         if (res.models && res.models.length) {
           const current = (select.hidden ? input.value : select.value).trim();
           const models = res.models.slice();
@@ -272,10 +274,13 @@
             `<option value="${esc(m)}" ${m === current ? "selected" : ""}>${esc(m)}</option>`).join("") +
             `<option value="__custom__">✎ enter manually…</option>`;
           show(true);
-          if (hint) hint.textContent = `${res.models.length} model${res.models.length === 1 ? "" : "s"} found on the server.`;
+          if (hint) hint.textContent = `${res.models.length} model${res.models.length === 1 ? "" : "s"} ` +
+            (connection ? "found on the server." : "in the local HF cache.");
         } else {
           show(false);
-          if (hint) hint.textContent = "No model list from the server — enter manually.";
+          if (hint) hint.textContent = connection
+            ? "No model list from the server — enter manually."
+            : "No cached models found in HF_HOME — enter a repo id manually.";
           if (!auto && res.detail) toast("Model discovery failed: " + res.detail, true);
         }
       } catch (e) {

--- a/webui_static/index.html
+++ b/webui_static/index.html
@@ -10,13 +10,13 @@
 <body>
 <div class="shell">
   <aside class="rail">
-    <div class="wordmark">
+    <a class="wordmark" href="#run" aria-label="Context Bench — back to Run">
       <span class="wordmark-sigil" aria-hidden="true"></span>
       <div>
         <div class="wordmark-title">Context Bench</div>
         <div class="wordmark-sub">LLM benchmarks</div>
       </div>
-    </div>
+    </a>
     <nav class="nav" id="nav">
       <a href="#run" data-view="run">
         <svg class="nav-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4.5 2.8v10.4l8-5.2z"/></svg>

--- a/webui_static/styles.css
+++ b/webui_static/styles.css
@@ -89,7 +89,7 @@ input, select, textarea { font: inherit; }
   top: 0;
   height: 100vh;
 }
-.wordmark { display: flex; gap: 10px; align-items: center; padding: 2px 10px 6px; }
+.wordmark { display: flex; gap: 10px; align-items: center; padding: 2px 10px 6px; color: inherit; text-decoration: none; cursor: pointer; }
 .wordmark-sigil {
   width: 26px; height: 26px; flex: none;
   border-radius: 7px;

--- a/webui_static/view-run.js
+++ b/webui_static/view-run.js
@@ -152,18 +152,21 @@
       if (!ollama && !connection.base_url && !connection.host) return null;
       return connection;
     };
+    // MLX has no server to query — its models live in the local HF cache.
+    const localEngine = engine.id === "mlx" ? "mlx" : null;
     state.runModelPicker = attachModelPicker({
       select: document.getElementById("rfModelSel"),
       input: document.getElementById("rfModel"),
       button: document.getElementById("rfModelLoad"),
       hint: document.getElementById("rfModelHint"),
       getConnection: runConnection,
+      localEngine,
     });
     for (const id of ["rfBaseUrl", "rfHost", "rfPort", "rfApiKey"]) {
       const node = document.getElementById(id);
       if (node) node.addEventListener("change", () => state.runModelPicker.load(true));
     }
-    if (runConnection()) {
+    if (runConnection() || localEngine) {
       state.runModelPicker.load(true).then(() => {
         if (ep && ep.model) state.runModelPicker.set(ep.model);
       });


### PR DESCRIPTION
## Changes

- **Sort engines alphabetically (ascending)** in the web UI engine dropdown.
  - Frontend renders engines in the order returned by `/api/meta`, which iterates `get_engine_catalog()` in insertion order.
  - Fixed at the source: `get_engine_catalog()` now returns `dict(sorted(catalog.items()))`, so all consumers (API + any caller) get alphabetical order.
- **Register unsloth engine** in the webui catalog (follow-up to `d1a40a4`, which added the engine itself).

## Verification
```
uv run python -c "from webui_engines import get_engine_catalog; print(list(get_engine_catalog().keys()))"
['afms', 'deepseek', 'dflash-mlx', 'exo', 'grok', 'llamacpp', 'lmstudio', 'mlx', 'mlx-distributed', 'mlx-vlm', 'mlx-vlm-server', 'mtplx', 'ollama-api', 'ollama-cli', 'omlx', 'openai', 'paroquant', 'unsloth', 'vllm', 'vmlx']
```
