### PR TITLE
Web UI: auto-fix /v1 base URLs and per-chart export selection

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -166,8 +166,6 @@ def summarize_result_folder(folder: Path):
         "gen_series": gen_series,
         "columns": sorted({k for r in rows for k in r.keys()}),
         "has_batch": bool(parsed["batch_data"]),
-        "has_perplexity": bool(parsed["perplexity_data"]),
-        "has_cached": bool(parsed["cached_results"]),
         "charts": charts,
     }
 

--- a/webui.py
+++ b/webui.py
@@ -73,6 +73,43 @@ def save_endpoints(endpoints: list):
         os.close(fd)
 
 
+def expects_v1_base_url(engine_id: str) -> bool:
+    """Engines whose script takes the base URL verbatim as an OpenAI-style
+    /v1 root advertise that through their default base URL."""
+    info = get_engine_catalog().get(engine_id) or {}
+    return (info.get("default_base_url") or "").rstrip("/").endswith("/v1")
+
+
+def normalize_base_url(base_url: str, engine_id: str, api_key: str = "") -> tuple[str, bool]:
+    """Append /v1 to a path-less base URL when the engine expects an OpenAI-style
+    /v1 root and the server actually answers there (probed, never guessed).
+
+    Returns (url, corrected). URLs that already carry a path, engines that
+    handle the prefix themselves (lmstudio, exo, mtplx, ...) and unreachable
+    servers are left untouched.
+    """
+    url = (base_url or "").strip().rstrip("/")
+    if not url or not expects_v1_base_url(engine_id):
+        return base_url, False
+    from urllib.parse import urlparse
+
+    if (urlparse(url).path or "").strip("/"):
+        return base_url, False
+    headers = {"User-Agent": "context-bench-webui"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        import httpx
+
+        if httpx.get(url + "/models", timeout=3.0, headers=headers).status_code < 400:
+            return base_url, False  # server genuinely serves at the root
+        if httpx.get(url + "/v1/models", timeout=3.0, headers=headers).status_code < 400:
+            return url + "/v1", True
+    except Exception:
+        pass  # unreachable right now — keep what the user entered
+    return base_url, False
+
+
 # ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
@@ -217,9 +254,10 @@ def api_endpoints_create(payload: dict):
         "port": payload.get("port") or "",
         "notes": payload.get("notes") or "",
     }
+    entry["base_url"], corrected = normalize_base_url(entry["base_url"], entry["engine"], entry["api_key"])
     endpoints.append(entry)
     save_endpoints(endpoints)
-    return entry
+    return {**entry, "base_url_corrected": corrected}
 
 
 @app.put("/api/endpoints/{endpoint_id}")
@@ -232,8 +270,11 @@ def api_endpoints_update(endpoint_id: str, payload: dict):
                     entry[key] = payload[key]
             if not (entry.get("name") or "").strip():
                 raise HTTPException(400, "Endpoint name is required")
+            entry["base_url"], corrected = normalize_base_url(
+                entry.get("base_url") or "", entry.get("engine") or "", entry.get("api_key") or ""
+            )
             save_endpoints(endpoints)
-            return entry
+            return {**entry, "base_url_corrected": corrected}
     raise HTTPException(404, "Endpoint not found")
 
 
@@ -334,6 +375,25 @@ def api_runs_start(payload: dict):
         endpoint = next((e for e in load_endpoints() if e["id"] == endpoint_id), None)
         if endpoint:
             endpoint_name = endpoint["name"]
+
+    # safety net for endpoints saved while their server was offline: probe a
+    # path-less base URL once more and self-heal the stored endpoint
+    connection = payload.get("connection") or {}
+    base_url = (connection.get("base_url") or "").strip()
+    if base_url:
+        corrected_url, corrected = normalize_base_url(base_url, engine_id, (connection.get("api_key") or "").strip())
+        if corrected:
+            connection["base_url"] = corrected_url
+            payload["connection"] = connection
+            if endpoint_id:
+                endpoints = load_endpoints()
+                for entry in endpoints:
+                    if entry["id"] == endpoint_id and (entry.get("base_url") or "").strip().rstrip(
+                        "/"
+                    ) == base_url.rstrip("/"):
+                        entry["base_url"] = corrected_url
+                        save_endpoints(endpoints)
+                        break
 
     argv, contexts = build_command(engine_id, payload)
     label = (payload.get("label") or "").strip() or endpoint_name

--- a/webui.py
+++ b/webui.py
@@ -73,13 +73,6 @@ def save_endpoints(endpoints: list):
         os.close(fd)
 
 
-def expects_v1_base_url(engine_id: str) -> bool:
-    """Engines whose script takes the base URL verbatim as an OpenAI-style
-    /v1 root advertise that through their default base URL."""
-    info = get_engine_catalog().get(engine_id) or {}
-    return (info.get("default_base_url") or "").rstrip("/").endswith("/v1")
-
-
 def normalize_base_url(base_url: str, engine_id: str, api_key: str = "") -> tuple[str, bool]:
     """Append /v1 to a path-less base URL when the engine expects an OpenAI-style
     /v1 root and the server actually answers there (probed, never guessed).
@@ -89,7 +82,9 @@ def normalize_base_url(base_url: str, engine_id: str, api_key: str = "") -> tupl
     servers are left untouched.
     """
     url = (base_url or "").strip().rstrip("/")
-    if not url or not expects_v1_base_url(engine_id):
+    # engines whose script wants the /v1 root advertise that via their default
+    info = get_engine_catalog().get(engine_id) or {}
+    if not url or not (info.get("default_base_url") or "").rstrip("/").endswith("/v1"):
         return base_url, False
     from urllib.parse import urlparse
 

--- a/webui_static/charts.js
+++ b/webui_static/charts.js
@@ -204,6 +204,37 @@
       }
     }
 
+    // static value labels at each point — for rasterized exports (PNG, PDF)
+    // where there is no hover tooltip. Labels sharing an x position are
+    // de-overlapped vertically, keeping the dots' top-to-bottom order so the
+    // color association stays readable.
+    if (opts.pointLabels) {
+      const GAP = 11;
+      const yTop = margin.top + 9;
+      const yBottom = margin.top + ih - 4;
+      const perX = new Map();
+      for (const s of series) {
+        for (const p of s.points) {
+          if (!perX.has(p[0])) perX.set(p[0], []);
+          perX.get(p[0]).push({ color: s.color, value: p[1], y: py(p[1]) - 8 });
+        }
+      }
+      for (const [xv, labels] of perX) {
+        const x = Math.min(Math.max(px(xv), margin.left + 16), width - margin.right - 16);
+        labels.sort((a, b) => a.y - b.y);
+        for (let i = 0; i < labels.length; i++) {
+          labels[i].y = Math.max(labels[i].y, yTop, i ? labels[i - 1].y + GAP : yTop);
+        }
+        // pushed past the plot bottom? shift the column back up
+        const overflow = labels[labels.length - 1].y - yBottom;
+        if (overflow > 0) for (const l of labels) l.y -= overflow;
+        for (const l of labels) {
+          const t = el("text", { x, y: l.y, "text-anchor": "middle", class: "point-label", fill: l.color }, svg);
+          t.textContent = fmtNum(l.value, opts);
+        }
+      }
+    }
+
     // crosshair + tooltip
     const crosshair = el("line", {
       y1: margin.top, y2: margin.top + ih, x1: 0, x2: 0,

--- a/webui_static/charts.js
+++ b/webui_static/charts.js
@@ -139,7 +139,9 @@
       const y = height - legendHeight + 14 + r * 20;
       for (const item of legendRows[r]) {
         const x = margin.left + item.x;
-        el("line", { x1: x, x2: x + 14, y1: y - 4, y2: y - 4, stroke: item.s.color, "stroke-width": 3 }, svg);
+        const swatch = { x1: x, x2: x + 14, y1: y - 4, y2: y - 4, stroke: item.s.color, "stroke-width": 3 };
+        if (item.s.dash) swatch["stroke-dasharray"] = "4 3";
+        el("line", swatch, svg);
         const t = el("text", {
           x: x + 20, y, fill: tok("--ink-2") || "#555",
           "font-family": "system-ui, sans-serif", "font-size": 11,
@@ -189,7 +191,9 @@
     // (standalone) SVGs can offer point tooltips without re-plumbing data
     for (const s of series) {
       const d = s.points.map((p, i) => `${i ? "L" : "M"}${px(p[0]).toFixed(1)},${py(p[1]).toFixed(1)}`).join("");
-      el("path", { d, class: "series-line", stroke: s.color }, svg);
+      const attrs = { d, class: "series-line", stroke: s.color };
+      if (s.dash) attrs["stroke-dasharray"] = "6 5";
+      el("path", attrs, svg);
       for (const p of s.points) {
         el("circle", {
           cx: px(p[0]), cy: py(p[1]), r: 4, fill: s.color, class: "series-dot",

--- a/webui_static/core.js
+++ b/webui_static/core.js
@@ -29,23 +29,41 @@
   };
 
   const METRICS = [
-    { key: "generation_tps", label: "Generation", unit: "tok/s" },
-    { key: "prompt_tps", label: "Prompt", unit: "tok/s" },
-    { key: "time_to_first_token", label: "TTFT", unit: "s", seconds: true },
-    { key: "time_per_output_token", label: "TPOT", unit: "s", seconds: true },
-    { key: "total_time", label: "Total time", unit: "s", seconds: true },
-    { key: "generation_utf8_bytes_per_sec", label: "Gen bytes/s", unit: "B/s" },
-    { key: "prompt_utf8_bytes_per_sec", label: "Prompt bytes/s", unit: "B/s" },
-    { key: "generation_chars_per_sec", label: "Gen chars/s", unit: "chars/s" },
-    { key: "prompt_chars_per_sec", label: "Prompt chars/s", unit: "chars/s" },
-    { key: "peak_memory_gb", label: "Peak memory", unit: "GB" },
-    { key: "host_memory_gb", label: "Host RAM", unit: "GB" },
-    { key: "kv_cache_gb", label: "KV cache", unit: "GB" },
-    { key: "kv_cache_usage_perc", label: "KV usage", unit: "%" },
+    { key: "generation_tps", label: "Generation", unit: "tok/s",
+      desc: "Decode speed: generated tokens per second of pure generation time. Higher is better." },
+    { key: "prompt_tps", label: "Prompt", unit: "tok/s",
+      desc: "Prefill speed: prompt tokens processed per second before generation starts. Higher is better." },
+    { key: "time_to_first_token", label: "TTFT", unit: "s", seconds: true,
+      desc: "Time to first token: how long from sending the request until the first generated token arrives — dominated by prompt processing. Lower is better." },
+    { key: "time_per_output_token", label: "TPOT", unit: "s", seconds: true,
+      desc: "Time per output token: average gap between two generated tokens once generation is running. Lower is better." },
+    { key: "total_time", label: "Total time", unit: "s", seconds: true,
+      desc: "Wall-clock time of the whole request: prompt processing plus generation." },
+    { key: "generation_utf8_bytes_per_sec", label: "Gen bytes/s", unit: "B/s",
+      desc: "Tokenizer-independent generation throughput: UTF-8 bytes of generated text per second — comparable across models with different tokenizers." },
+    { key: "prompt_utf8_bytes_per_sec", label: "Prompt bytes/s", unit: "B/s",
+      desc: "Tokenizer-independent prefill throughput: UTF-8 bytes of prompt text processed per second." },
+    { key: "generation_chars_per_sec", label: "Gen chars/s", unit: "chars/s",
+      desc: "Generated Unicode characters per second — like bytes/s but counting characters, so multi-byte scripts read naturally." },
+    { key: "prompt_chars_per_sec", label: "Prompt chars/s", unit: "chars/s",
+      desc: "Prompt Unicode characters processed per second — tokenizer-independent prefill throughput in characters." },
+    { key: "peak_memory_gb", label: "Peak memory", unit: "GB",
+      desc: "Peak accelerator/unified memory used during the run (reported by the framework, e.g. MLX)." },
+    { key: "host_memory_gb", label: "Host RAM", unit: "GB",
+      desc: "Resident memory of the server process, sampled while the benchmark ran." },
+    { key: "kv_cache_gb", label: "KV cache", unit: "GB",
+      desc: "Size of the key-value cache after the context was processed — grows with context length." },
+    { key: "kv_cache_usage_perc", label: "KV usage", unit: "%",
+      desc: "Share of the server's KV-cache pool in use (as reported by e.g. vLLM or llama.cpp)." },
   ];
 
   function metricsForKeys(keys) {
     return METRICS.filter(m => keys.has(m.key));
+  }
+
+  // hoverable »?« that explains a metric; keyboard-reachable via tabindex
+  function qmarkHtml(desc) {
+    return desc ? `<span class="qmark" tabindex="0" data-tip="${esc(desc)}">?</span>` : "";
   }
 
   // ----------------------------------------------------------------- utils
@@ -340,7 +358,7 @@
   }
 
   window.CB = {
-    state, METRICS, metricsForKeys,
+    state, METRICS, metricsForKeys, qmarkHtml,
     esc, fmt, api, toast,
     seriesColor, ctxNum, cachedSeriesPoints, fmtDate, fmtDuration,
     pageHead, resultName, resultSubtitle, seriesLabel, matchesFilter, engineById, endpointTarget,

--- a/webui_static/core.js
+++ b/webui_static/core.js
@@ -20,6 +20,7 @@
       slots: new Map(),    // folder -> color slot index (0..7)
       metric: "generation_tps",
       grid: false,
+      baseline: null,      // folder shown as 100% — null = absolute values
     },
     resultsFilter: "",
     runFormEngine: null,
@@ -35,6 +36,8 @@
     { key: "total_time", label: "Total time", unit: "s", seconds: true },
     { key: "generation_utf8_bytes_per_sec", label: "Gen bytes/s", unit: "B/s" },
     { key: "prompt_utf8_bytes_per_sec", label: "Prompt bytes/s", unit: "B/s" },
+    { key: "generation_chars_per_sec", label: "Gen chars/s", unit: "chars/s" },
+    { key: "prompt_chars_per_sec", label: "Prompt chars/s", unit: "chars/s" },
     { key: "peak_memory_gb", label: "Peak memory", unit: "GB" },
     { key: "host_memory_gb", label: "Host RAM", unit: "GB" },
     { key: "kv_cache_gb", label: "KV cache", unit: "GB" },
@@ -78,6 +81,25 @@
   function ctxNum(ctx) {
     const v = parseFloat(String(ctx).replace(/k$/i, ""));
     return isFinite(v) ? v : 0;
+  }
+
+  // KV-cache-reuse runs (MLX --cached) carry warm re-prompt measurements in
+  // cached_results; these map onto the cold metrics as dashed overlays.
+  const CACHED_METRIC_FIELDS = {
+    prompt_tps: "incremental_prompt_tps",
+    generation_tps: "generation_tps",
+    time_to_first_token: "time_to_first_token",
+  };
+
+  function cachedSeriesPoints(detail, metricKey) {
+    const field = CACHED_METRIC_FIELDS[metricKey];
+    const rows = detail.cached_results;
+    if (!field || !rows || !rows.length) return null;
+    const points = rows
+      .map(r => [ctxNum(r.context_size), r[field]])
+      .filter(p => p[1] != null && isFinite(p[1]) && p[1] > 0)
+      .sort((a, b) => a[0] - b[0]);
+    return points.length ? points : null;
   }
 
   function fmtDate(iso) {
@@ -320,7 +342,7 @@
   window.CB = {
     state, METRICS, metricsForKeys,
     esc, fmt, api, toast,
-    seriesColor, ctxNum, fmtDate, fmtDuration,
+    seriesColor, ctxNum, cachedSeriesPoints, fmtDate, fmtDuration,
     pageHead, resultName, resultSubtitle, seriesLabel, matchesFilter, engineById, endpointTarget,
     ensureResults, ensureDetail, toggleCompare,
     openModal, closeModal, initTheme,

--- a/webui_static/core.js
+++ b/webui_static/core.js
@@ -31,7 +31,7 @@
   const METRICS = [
     { key: "generation_tps", label: "Generation", unit: "tok/s",
       desc: "Decode speed: generated tokens per second of pure generation time. Higher is better." },
-    { key: "prompt_tps", label: "Prompt", unit: "tok/s",
+    { key: "prompt_tps", label: "Prompt processing", unit: "tok/s",
       desc: "Prefill speed: prompt tokens processed per second before generation starts. Higher is better." },
     { key: "time_to_first_token", label: "TTFT", unit: "s", seconds: true,
       desc: "Time to first token: how long from sending the request until the first generated token arrives — dominated by prompt processing. Lower is better." },

--- a/webui_static/export.js
+++ b/webui_static/export.js
@@ -81,7 +81,8 @@
   // --------------------------------------------------------- SVG -> canvas
 
   const INLINE_PROPS = ["fill", "stroke", "stroke-width", "stroke-linecap", "stroke-linejoin",
-    "opacity", "font-family", "font-size", "font-weight", "letter-spacing", "visibility"];
+    "stroke-dasharray", "paint-order", "opacity", "font-family", "font-size", "font-weight",
+    "letter-spacing", "visibility"];
 
   async function svgToCanvas(svgEl, scale, background) {
     const clone = svgEl.cloneNode(true);

--- a/webui_static/export.js
+++ b/webui_static/export.js
@@ -206,8 +206,20 @@
     return s.length >= width ? s : s + " ".repeat(width - s.length);
   }
 
-  // shared tabular model for TXT / HTML / PDF: one table per metric
-  function buildTables(entries, metrics, fmt) {
+  function wrapText(text, max) {
+    const lines = [];
+    let line = "";
+    for (const word of String(text).split(/\s+/)) {
+      if (line && (line + " " + word).length > max) { lines.push(line); line = word; }
+      else line = line ? line + " " + word : word;
+    }
+    if (line) lines.push(line);
+    return lines;
+  }
+
+  // shared tabular model for TXT / HTML / PDF: one table per metric, plus
+  // cached re-prompt tables and one table per batch chart
+  function buildTables(entries, metrics, fmt, batchDefs) {
     const contexts = [...new Set(entries.flatMap(e => e.detail.results.map(r => r.context_size)))]
       .sort((a, b) => parseFloat(a) - parseFloat(b));
     const tables = [];
@@ -220,25 +232,57 @@
       if (!rows.some(r => r.slice(1).some(v => v != null))) continue;
       tables.push({
         title: `${metric.label} [${metric.unit}]`,
+        desc: metric.desc,
         headers: ["context"].concat(entries.map(e => e.name)),
         rows,
       });
     }
+
+    const withCached = entries.filter(e => e.detail.cached_results && e.detail.cached_results.length);
+    if (withCached.length) {
+      const cachedDefs = [
+        { key: "incremental_prompt_tps", title: "Cached re-prompt — incremental prompt [tok/s]",
+          desc: "Prefill speed on top of a stored KV cache, counting only the tokens added after the cached prefix." },
+        { key: "generation_tps", title: "Cached re-prompt — generation [tok/s]",
+          desc: "Decode speed of the warm run that reused the stored KV cache." },
+        { key: "time_to_first_token", title: "Cached re-prompt — TTFT [s]", seconds: true,
+          desc: "Time to first token when the context prefix is already cached. Lower is better." },
+      ];
+      const cachedContexts = [...new Set(withCached.flatMap(e => e.detail.cached_results.map(r => r.context_size)))]
+        .sort((a, b) => parseFloat(a) - parseFloat(b));
+      for (const def of cachedDefs) {
+        const rows = cachedContexts.map(ctx => [ctx].concat(entries.map(e => {
+          const row = (e.detail.cached_results || []).find(r => r.context_size === ctx);
+          return row && row[def.key] != null && isFinite(row[def.key]) && row[def.key] > 0
+            ? fmt(row[def.key], { seconds: def.seconds }) : null;
+        })));
+        if (!rows.some(r => r.slice(1).some(v => v != null))) continue;
+        tables.push({
+          title: def.title,
+          desc: def.desc,
+          headers: ["context"].concat(entries.map(e => e.name)),
+          rows,
+        });
+      }
+    }
+
     const withBatch = entries.filter(e => e.detail.batch_data && e.detail.batch_data.length);
-    if (withBatch.length) {
+    if (withBatch.length && batchDefs) {
       const batchSizes = [...new Set(withBatch.flatMap(e => e.detail.batch_data.map(b => b.batch_size)))]
         .sort((a, b) => a - b);
-      const hasDecode = withBatch.some(e => e.detail.batch_data.some(b => b.decode_tps_total != null));
-      tables.push({
-        title: `Batch sweep [prompt / e2e-gen${hasDecode ? " / decode" : ""} tok/s, N parallel clients]`,
-        headers: ["batch"].concat(withBatch.map(e => e.name)),
-        rows: batchSizes.map(bs => [bs].concat(withBatch.map(e => {
-          const row = e.detail.batch_data.find(b => b.batch_size === bs);
-          if (!row) return null;
-          const cell = `${fmt(row.prompt_tps)} / ${fmt(row.generation_tps)}`;
-          return row.decode_tps_total != null ? `${cell} / ${fmt(row.decode_tps_total)}` : cell;
-        }))),
-      });
+      for (const def of batchDefs) {
+        const rows = batchSizes.map(bs => [bs].concat(entries.map(e => {
+          const row = (e.detail.batch_data || []).find(b => b.batch_size === bs);
+          return row && row[def.field] > 0 ? fmt(row[def.field], { seconds: def.seconds }) : null;
+        })));
+        if (!rows.some(r => r.slice(1).some(v => v != null))) continue;
+        tables.push({
+          title: def.title,
+          desc: def.desc,
+          headers: ["batch"].concat(entries.map(e => e.name)),
+          rows,
+        });
+      }
     }
     return tables;
   }
@@ -259,6 +303,7 @@
     lines.push("");
     for (const table of tables) {
       lines.push(`== ${table.title} ==`);
+      if (table.desc) lines.push(`   ${table.desc}`);
       const widths = table.headers.map((h, i) =>
         Math.max(h.length, ...table.rows.map(r => (r[i] == null ? 1 : String(r[i]).length))) + 2);
       lines.push(table.headers.map((h, i) => pad(h, widths[i])).join(""));
@@ -287,13 +332,14 @@
     const legendHtml = (legend || []).length < 2 ? "" :
       `<div class="legend">${legend.map(l =>
         `<span class="legend-item"><span class="legend-swatch" style="background:${l.color}"></span>${h(l.name)}</span>`).join("")}</div>`;
+    const qmark = desc => (desc ? `<span class="qmark" tabindex="0" data-tip="${h(desc)}">?</span>` : "");
     const chartsHtml = charts.map(c => `<figure>
-      <figcaption>${h(c.title)}</figcaption>
+      <figcaption>${h(c.title)}${qmark(c.desc)}</figcaption>
       <div class="viz">${c.svg}</div>
       ${legendHtml}
     </figure>`).join("\n");
     const tablesHtml = tables.map(t => `
-      <h2>${h(t.title)}</h2>
+      <h2>${h(t.title)}${qmark(t.desc)}</h2>
       <table><thead><tr>${t.headers.map((x, i) =>
         `<th${i ? "" : ' class="left"'}>${h(x)}</th>`).join("")}</tr></thead>
       <tbody>${t.rows.map(r => `<tr>${r.map((v, i) =>
@@ -363,6 +409,19 @@
   .legend { display: flex; flex-wrap: wrap; gap: 6px 16px; padding-top: 10px; }
   .legend-item { display: flex; align-items: center; gap: 7px; font-size: 12px; color: var(--ink-2); }
   .legend-swatch { width: 14px; height: 3px; border-radius: 2px; display: inline-block; }
+  .qmark { display: inline-flex; align-items: center; justify-content: center;
+    width: 15px; height: 15px; margin-left: 7px; vertical-align: 1px;
+    border: 1px solid var(--axis); border-radius: 50%;
+    color: var(--muted); font: 600 9.5px/1 ui-monospace, Menlo, monospace;
+    cursor: help; position: relative; }
+  .qmark:hover { color: var(--ink); border-color: var(--muted); }
+  .qmark::after { content: attr(data-tip); position: absolute; left: -20px; top: calc(100% + 8px);
+    width: 300px; background: var(--raised); border: 1px solid var(--hairline); border-radius: 8px;
+    padding: 8px 11px; font: 400 12px/1.5 system-ui, sans-serif; color: var(--ink-2);
+    text-align: left; text-transform: none; letter-spacing: normal; white-space: normal;
+    box-shadow: 0 8px 30px rgba(0,0,0,.35); z-index: 20;
+    opacity: 0; visibility: hidden; transition: opacity 120ms ease; pointer-events: none; }
+  .qmark:hover::after, .qmark:focus::after { opacity: 1; visibility: visible; }
   .pt-tip { position: fixed; z-index: 10; pointer-events: none;
     background: var(--raised); border: 1px solid var(--hairline); border-radius: 8px;
     padding: 7px 10px; font-size: 12px; box-shadow: 0 8px 30px rgba(0,0,0,.35); max-width: 320px; }
@@ -664,12 +723,20 @@ ${tablesHtml}
       pdf.addPage();
       pdf.text(M, 44, chart.title, { bold: true, size: 13 });
       pdf.line(M, 56, pdf.W - M, 56, 0.2);
+      let iy = 72;
+      if (chart.desc) {
+        for (const line of wrapText(chart.desc, 100)) {
+          pdf.text(M, iy, line, { size: 9, color: [0.45, 0.44, 0.4] });
+          iy += 12;
+        }
+        iy += 6;
+      }
       const maxW = pdf.W - 2 * M;
-      const maxH = pdf.H - 100;
+      const maxH = pdf.H - iy - 40;
       const ratio = Math.min(maxW / chart.jpeg.width, maxH / chart.jpeg.height);
       const w = chart.jpeg.width * ratio;
       const h = chart.jpeg.height * ratio;
-      pdf.image(chart.jpeg, M + (maxW - w) / 2, 72, w, h);
+      pdf.image(chart.jpeg, M + (maxW - w) / 2, iy, w, h);
     }
 
     // --- data tables (monospace) ---
@@ -690,6 +757,13 @@ ${tablesHtml}
       if (ty === Infinity || room() < Math.min(neededRows, 6) * lineHeight) newDataPage();
       pdf.text(M, ty, table.title, { bold: true, size: 10.5 });
       ty += 16;
+      if (table.desc) {
+        for (const line of wrapText(table.desc, 110)) {
+          pdf.text(M, ty, line, { size: 8, color: [0.45, 0.44, 0.4] });
+          ty += 11;
+        }
+        ty += 2;
+      }
       pdf.text(M, ty, headerLine, { mono: true, size: 8.5, color: [0.45, 0.44, 0.4] });
       ty += 4;
       pdf.line(M, ty, pdf.W - M, ty, 0.6);

--- a/webui_static/export.js
+++ b/webui_static/export.js
@@ -138,7 +138,7 @@
   }
 
   function buildResultsCsv(entries) {
-    const metaCols = ["run", "engine", "model", "machine", "folder"];
+    const metaCols = ["run", "engine", "model", "endpoint", "folder"];
     const dataCols = [];
     for (const e of entries) {
       for (const row of e.detail.results) {
@@ -152,7 +152,7 @@
       const s = e.detail.summary;
       for (const row of e.detail.results) {
         lines.push(metaCols.map(c => csvEscape({
-          run: e.name, engine: s.engine, model: s.model, machine: s.machine, folder: s.folder,
+          run: e.name, engine: s.engine, model: s.model, endpoint: s.endpoint, folder: s.folder,
         }[c])).concat(dataCols.map(c => csvEscape(row[c]))).join(","));
       }
     }
@@ -296,8 +296,9 @@
     entries.forEach((e, i) => {
       const s = e.detail.summary;
       lines.push(`  [${i + 1}] ${e.name}`);
-      lines.push(`      ${s.engine} · ${s.model}${s.machine ? " · " + s.machine : ""}`);
-      if (s.hardware) lines.push(`      ${s.hardware}`);
+      // deliberately no local hardware info: for endpoint runs the inference
+      // ran elsewhere — the endpoint name is the machine that matters
+      lines.push(`      ${s.engine} · ${s.model}${s.endpoint ? " · " + s.endpoint : ""}`);
       lines.push(`      ${s.folder}`);
     });
     lines.push("");
@@ -327,7 +328,7 @@
       const s = e.detail.summary;
       return `<tr><td class="idx">${i + 1}</td><td><strong>${h(e.name)}</strong></td>
         <td>${h(s.engine)}</td><td class="mono">${h(s.model)}</td>
-        <td>${h(s.machine || "–")}</td><td class="mono small">${h(s.folder)}</td></tr>`;
+        <td>${h(s.endpoint || "–")}</td><td class="mono small">${h(s.folder)}</td></tr>`;
     }).join("");
     const legendHtml = (legend || []).length < 2 ? "" :
       `<div class="legend">${legend.map(l =>
@@ -443,7 +444,7 @@
 </header>
 <h2>Runs</h2>
 <table><thead><tr><th class="left"></th><th class="left">Run</th><th class="left">Engine</th>
-<th class="left">Model</th><th class="left">Machine</th><th class="left">Folder</th></tr></thead>
+<th class="left">Model</th><th class="left">Endpoint</th><th class="left">Folder</th></tr></thead>
 <tbody>${runsHtml}</tbody></table>
 ${chartsHtml}
 ${tablesHtml}
@@ -711,9 +712,10 @@ ${tablesHtml}
       const s = e.detail.summary;
       pdf.text(M, y, `${i + 1}.  ${e.name}`, { bold: true, size: 11 });
       y += 15;
-      pdf.text(M + 16, y, `${s.engine} · ${s.model}${s.machine ? " · " + s.machine : ""}`, { size: 9.5, color: [0.32, 0.32, 0.3] });
+      // deliberately no local hardware info: for endpoint runs the inference
+      // ran elsewhere — the endpoint name is the machine that matters
+      pdf.text(M + 16, y, `${s.engine} · ${s.model}${s.endpoint ? " · " + s.endpoint : ""}`, { size: 9.5, color: [0.32, 0.32, 0.3] });
       y += 13;
-      if (s.hardware) { pdf.text(M + 16, y, s.hardware, { size: 9, color: [0.55, 0.53, 0.5] }); y += 13; }
       pdf.text(M + 16, y, s.folder, { mono: true, size: 8, color: [0.55, 0.53, 0.5] });
       y += 20;
     });

--- a/webui_static/export.js
+++ b/webui_static/export.js
@@ -179,6 +179,28 @@
     return lines.join("\n") + "\n";
   }
 
+  function buildCachedCsv(entries) {
+    const withCached = entries.filter(e => e.detail.cached_results && e.detail.cached_results.length);
+    if (!withCached.length) return null;
+    const dataCols = [];
+    for (const e of withCached) {
+      for (const row of e.detail.cached_results) {
+        for (const key of Object.keys(row)) {
+          if (key !== "generated_text" && key !== "reasoning_text" && !dataCols.includes(key)) dataCols.push(key);
+        }
+      }
+    }
+    const lines = [["run", "engine", "model"].concat(dataCols).join(",")];
+    for (const e of withCached) {
+      const s = e.detail.summary;
+      for (const row of e.detail.cached_results) {
+        lines.push([csvEscape(e.name), csvEscape(s.engine), csvEscape(s.model)]
+          .concat(dataCols.map(c => csvEscape(row[c]))).join(","));
+      }
+    }
+    return lines.join("\n") + "\n";
+  }
+
   function pad(value, width) {
     const s = value == null ? "–" : String(value);
     return s.length >= width ? s : s + " ".repeat(width - s.length);
@@ -698,7 +720,7 @@ ${tablesHtml}
 
   window.CBExport = {
     makeZip, svgToCanvas, canvasToPngBytes, canvasToJpeg,
-    buildResultsCsv, buildBatchCsv, buildTables, buildComparisonTxt,
+    buildResultsCsv, buildBatchCsv, buildCachedCsv, buildTables, buildComparisonTxt,
     buildHtmlReport, buildPdfReport, composeOverview, download,
   };
 })();

--- a/webui_static/export.js
+++ b/webui_static/export.js
@@ -160,19 +160,25 @@
     return lines.join("\n") + "\n";
   }
 
-  function buildBatchCsv(entries) {
-    const withBatch = entries.filter(e => e.detail.batch_data && e.detail.batch_data.length);
-    if (!withBatch.length) return null;
+  // batch and cached CSVs share this shape: run/engine/model meta columns
+  // plus the union of every row key across the selected runs
+  function buildRunRowsCsv(entries, getRows) {
+    const withRows = entries
+      .map(e => ({ e, rows: getRows(e.detail) || [] }))
+      .filter(x => x.rows.length);
+    if (!withRows.length) return null;
     const dataCols = [];
-    for (const e of withBatch) {
-      for (const row of e.detail.batch_data) {
-        for (const key of Object.keys(row)) if (!dataCols.includes(key)) dataCols.push(key);
+    for (const { rows } of withRows) {
+      for (const row of rows) {
+        for (const key of Object.keys(row)) {
+          if (key !== "generated_text" && key !== "reasoning_text" && !dataCols.includes(key)) dataCols.push(key);
+        }
       }
     }
     const lines = [["run", "engine", "model"].concat(dataCols).join(",")];
-    for (const e of withBatch) {
+    for (const { e, rows } of withRows) {
       const s = e.detail.summary;
-      for (const row of e.detail.batch_data) {
+      for (const row of rows) {
         lines.push([csvEscape(e.name), csvEscape(s.engine), csvEscape(s.model)]
           .concat(dataCols.map(c => csvEscape(row[c]))).join(","));
       }
@@ -180,27 +186,8 @@
     return lines.join("\n") + "\n";
   }
 
-  function buildCachedCsv(entries) {
-    const withCached = entries.filter(e => e.detail.cached_results && e.detail.cached_results.length);
-    if (!withCached.length) return null;
-    const dataCols = [];
-    for (const e of withCached) {
-      for (const row of e.detail.cached_results) {
-        for (const key of Object.keys(row)) {
-          if (key !== "generated_text" && key !== "reasoning_text" && !dataCols.includes(key)) dataCols.push(key);
-        }
-      }
-    }
-    const lines = [["run", "engine", "model"].concat(dataCols).join(",")];
-    for (const e of withCached) {
-      const s = e.detail.summary;
-      for (const row of e.detail.cached_results) {
-        lines.push([csvEscape(e.name), csvEscape(s.engine), csvEscape(s.model)]
-          .concat(dataCols.map(c => csvEscape(row[c]))).join(","));
-      }
-    }
-    return lines.join("\n") + "\n";
-  }
+  const buildBatchCsv = entries => buildRunRowsCsv(entries, d => d.batch_data);
+  const buildCachedCsv = entries => buildRunRowsCsv(entries, d => d.cached_results);
 
   function pad(value, width) {
     const s = value == null ? "–" : String(value);
@@ -219,8 +206,9 @@
   }
 
   // shared tabular model for TXT / HTML / PDF: one table per metric, plus
-  // cached re-prompt tables and one table per batch chart
-  function buildTables(entries, metrics, fmt, batchDefs) {
+  // cached re-prompt tables and one table per batch chart (the def lists —
+  // titles, fields, descriptions — come from the caller, see report.js)
+  function buildTables(entries, metrics, fmt, batchDefs, cachedDefs) {
     const contexts = [...new Set(entries.flatMap(e => e.detail.results.map(r => r.context_size)))]
       .sort((a, b) => parseFloat(a) - parseFloat(b));
     const tables = [];
@@ -239,52 +227,31 @@
       });
     }
 
-    const withCached = entries.filter(e => e.detail.cached_results && e.detail.cached_results.length);
-    if (withCached.length) {
-      const cachedDefs = [
-        { key: "incremental_prompt_tps", title: "Cached re-prompt — incremental prompt [tok/s]",
-          desc: "Prefill speed on top of a stored KV cache, counting only the tokens added after the cached prefix." },
-        { key: "generation_tps", title: "Cached re-prompt — generation [tok/s]",
-          desc: "Decode speed of the warm run that reused the stored KV cache." },
-        { key: "time_to_first_token", title: "Cached re-prompt — TTFT [s]", seconds: true,
-          desc: "Time to first token when the context prefix is already cached. Lower is better." },
-      ];
-      const cachedContexts = [...new Set(withCached.flatMap(e => e.detail.cached_results.map(r => r.context_size)))]
-        .sort((a, b) => parseFloat(a) - parseFloat(b));
-      for (const def of cachedDefs) {
-        const rows = cachedContexts.map(ctx => [ctx].concat(entries.map(e => {
-          const row = (e.detail.cached_results || []).find(r => r.context_size === ctx);
-          return row && row[def.key] != null && isFinite(row[def.key]) && row[def.key] > 0
-            ? fmt(row[def.key], { seconds: def.seconds }) : null;
+    // cached and batch tables share one shape: a table per def, rows keyed by
+    // an x column (context or batch size) across all runs. Zero/absent values
+    // mean »not recorded« and stay empty.
+    const pushDefTables = (defs, getRows, xField, xHeader, xSort) => {
+      const withRows = entries.filter(e => (getRows(e.detail) || []).length);
+      if (!withRows.length || !defs) return;
+      const xs = [...new Set(withRows.flatMap(e => getRows(e.detail).map(r => r[xField])))].sort(xSort);
+      for (const def of defs) {
+        const field = def.field || def.key;
+        const rows = xs.map(x => [x].concat(entries.map(e => {
+          const row = (getRows(e.detail) || []).find(r => r[xField] === x);
+          const value = row ? row[field] : null;
+          return value > 0 && isFinite(value) ? fmt(value, { seconds: def.seconds }) : null;
         })));
         if (!rows.some(r => r.slice(1).some(v => v != null))) continue;
         tables.push({
-          title: def.title,
+          title: `${def.title} [${def.unit}]`,
           desc: def.desc,
-          headers: ["context"].concat(entries.map(e => e.name)),
+          headers: [xHeader].concat(entries.map(e => e.name)),
           rows,
         });
       }
-    }
-
-    const withBatch = entries.filter(e => e.detail.batch_data && e.detail.batch_data.length);
-    if (withBatch.length && batchDefs) {
-      const batchSizes = [...new Set(withBatch.flatMap(e => e.detail.batch_data.map(b => b.batch_size)))]
-        .sort((a, b) => a - b);
-      for (const def of batchDefs) {
-        const rows = batchSizes.map(bs => [bs].concat(entries.map(e => {
-          const row = (e.detail.batch_data || []).find(b => b.batch_size === bs);
-          return row && row[def.field] > 0 ? fmt(row[def.field], { seconds: def.seconds }) : null;
-        })));
-        if (!rows.some(r => r.slice(1).some(v => v != null))) continue;
-        tables.push({
-          title: def.title,
-          desc: def.desc,
-          headers: ["batch"].concat(entries.map(e => e.name)),
-          rows,
-        });
-      }
-    }
+    };
+    pushDefTables(cachedDefs, d => d.cached_results, "context_size", "context", (a, b) => parseFloat(a) - parseFloat(b));
+    pushDefTables(batchDefs, d => d.batch_data, "batch_size", "batch", (a, b) => a - b);
     return tables;
   }
 

--- a/webui_static/report.js
+++ b/webui_static/report.js
@@ -82,6 +82,7 @@
 
     try {
       for (const metric of metrics) {
+        if (only && !only.has(metric.key)) continue;
         await render(
           seriesFor(e => e.detail.results.map(r => [ctxNum(r.context_size), r[metric.key]])),
           { height, seconds: metric.seconds, xLabel: "context (tokens ×1000)", yLabel: metric.unit },
@@ -121,13 +122,12 @@
   // charts are rendered; tables and CSVs always keep the full data
   async function exportRuns(entries, format, baseName, title, only) {
     const metrics = metricsForEntries(entries);
-    const chartMetrics = only ? metrics.filter(m => only.has(m.key)) : metrics;
     const tables = CBExport.buildTables(entries, metrics, fmt);
     const stamp = new Date().toISOString().slice(0, 16).replace(/[T:]/g, "-");
 
     if (format === "zip") {
       // one compact dashboard PNG instead of a folder of single charts
-      const charts = await renderExportCharts(entries, chartMetrics,
+      const charts = await renderExportCharts(entries, metrics,
         { width: 720, height: 330, batchHeight: 300, legend: false, only });
       const encoder = new TextEncoder();
       const files = [];
@@ -156,7 +156,7 @@
     if (format === "html") {
       // interactive SVG charts: theme with the report's toggle, points show
       // their values on hover/click
-      const charts = await renderExportCharts(entries, chartMetrics,
+      const charts = await renderExportCharts(entries, metrics,
         { raw: true, width: 1060, height: 420, batchHeight: 380, only });
       const legend = entries.map(e => ({ name: e.name, color: seriesColor(e.slot || 0) }));
       const html = CBExport.buildHtmlReport(title, entries, tables, charts, legend);
@@ -165,7 +165,7 @@
     }
 
     // pdf — always the print-friendly light style
-    const charts = await renderExportCharts(entries, chartMetrics, { theme: "light", only });
+    const charts = await renderExportCharts(entries, metrics, { theme: "light", only });
     const chartData = [];
     for (const c of charts) chartData.push({ title: c.title, jpeg: await CBExport.canvasToJpeg(c.canvas) });
     const pdf = CBExport.buildPdfReport(title, entries, tables, chartData);
@@ -252,5 +252,5 @@
     </span>`;
   }
 
-  CB.report = { metricsForEntries, batchChartDefs, wireExportGroup, exportGroupHtml };
+  CB.report = { batchChartDefs, wireExportGroup, exportGroupHtml };
 })();

--- a/webui_static/report.js
+++ b/webui_static/report.js
@@ -15,9 +15,20 @@
   function chartChoices(entries) {
     return [
       ...metricsForEntries(entries).map(m => ({ key: m.key, label: `${m.label} (${m.unit})`, desc: m.desc })),
-      ...batchChartDefs(entries).map(d => ({ key: d.key, label: d.title.replace(/ \[.+\]$/, ""), desc: d.desc })),
+      ...batchChartDefs(entries).map(d => ({ key: d.key, label: d.title, desc: d.desc })),
     ];
   }
+
+  // table companions to the cached chart overlays (see core.js
+  // CACHED_METRIC_FIELDS): what a KV-cache-reuse run gets tabulated as
+  const CACHED_TABLE_DEFS = [
+    { key: "incremental_prompt_tps", title: "Cached re-prompt — incremental prompt", unit: "tok/s",
+      desc: "Prefill speed on top of a stored KV cache, counting only the tokens added after the cached prefix." },
+    { key: "generation_tps", title: "Cached re-prompt — generation", unit: "tok/s",
+      desc: "Decode speed of the warm run that reused the stored KV cache." },
+    { key: "time_to_first_token", title: "Cached re-prompt — TTFT", unit: "s", seconds: true,
+      desc: "Time to first token when the context prefix is already cached. Lower is better." },
+  ];
 
   // deselected chart keys survive across exports (stored as the off-list so
   // metrics that appear later default to on)
@@ -36,33 +47,33 @@
     if (!withBatch.length) return [];
     const has = field => withBatch.some(e => e.detail.batch_data.some(b => b[field] != null && b[field] > 0));
     const defs = [
-      { key: "batch_prompt", title: "Batch — prompt throughput [tok/s]", field: "prompt_tps",
+      { key: "batch_prompt", title: "Batch — prompt throughput", unit: "tok/s", field: "prompt_tps",
         desc: "Prompt (prefill) throughput summed across N parallel clients. Higher is better." },
-      { key: "batch_e2e", title: "Batch — end-to-end gen throughput [tok/s]", field: "generation_tps",
+      { key: "batch_e2e", title: "Batch — end-to-end gen throughput", unit: "tok/s", field: "generation_tps",
         desc: "End-to-end generation throughput: generated tokens ÷ total wall time including the prompt phase, summed across clients." },
     ];
     if (has("decode_tps_total")) {
-      defs.push({ key: "batch_decode", title: "Batch — decode throughput [tok/s]", field: "decode_tps_total",
+      defs.push({ key: "batch_decode", title: "Batch — decode throughput", unit: "tok/s", field: "decode_tps_total",
         desc: "Pure generation rate the server reported, summed across clients — prompt phase excluded." });
     }
     if (has("time_to_first_token")) {
-      defs.push({ key: "batch_ttft", title: "Batch — TTFT [s]", field: "time_to_first_token", seconds: true,
+      defs.push({ key: "batch_ttft", title: "Batch — TTFT", unit: "s", field: "time_to_first_token", seconds: true,
         desc: "Time to first token at this concurrency — the wait each client sees under load. Lower is better." });
     }
     if (has("time_per_output_token")) {
-      defs.push({ key: "batch_tpot", title: "Batch — TPOT [s]", field: "time_per_output_token", seconds: true,
+      defs.push({ key: "batch_tpot", title: "Batch — TPOT", unit: "s", field: "time_per_output_token", seconds: true,
         desc: "Average gap between two generated tokens at this concurrency. Lower is better." });
     }
     if (has("peak_memory_gb")) {
-      defs.push({ key: "batch_peak_mem", title: "Batch — peak memory [GB]", field: "peak_memory_gb",
+      defs.push({ key: "batch_peak_mem", title: "Batch — peak memory", unit: "GB", field: "peak_memory_gb",
         desc: "Peak accelerator/unified memory while serving N clients in parallel." });
     }
     if (has("kv_cache_gb")) {
-      defs.push({ key: "batch_kv", title: "Batch — KV cache [GB]", field: "kv_cache_gb",
+      defs.push({ key: "batch_kv", title: "Batch — KV cache", unit: "GB", field: "kv_cache_gb",
         desc: "Key-value-cache size with N concurrent sequences — grows with concurrency." });
     }
     if (has("host_memory_gb")) {
-      defs.push({ key: "batch_host_mem", title: "Batch — host RAM [GB]", field: "host_memory_gb",
+      defs.push({ key: "batch_host_mem", title: "Batch — host RAM", unit: "GB", field: "host_memory_gb",
         desc: "Resident memory of the server process while serving N clients in parallel." });
     }
     return defs;
@@ -128,9 +139,9 @@
         await render(
           // engines write 0 when a batch metric is unavailable — not a data point
           seriesFor(e => (e.detail.batch_data || []).map(b => [b.batch_size, b[def.field] > 0 ? b[def.field] : null])),
-          { height: batchHeight, seconds: def.seconds, xLabel: "batch size (parallel clients)", yLabel: def.title.match(/\[(.+)\]/)[1], xTickFormat: v => String(v) },
+          { height: batchHeight, seconds: def.seconds, xLabel: "batch size (parallel clients)", yLabel: def.unit, xTickFormat: v => String(v) },
           def.key,
-          def.title,
+          `${def.title} [${def.unit}]`,
           def.desc,
         );
       }
@@ -157,7 +168,7 @@
   // charts are rendered; tables and CSVs always keep the full data
   async function exportRuns(entries, format, baseName, title, only) {
     const metrics = metricsForEntries(entries);
-    const tables = CBExport.buildTables(entries, metrics, fmt, batchChartDefs(entries));
+    const tables = CBExport.buildTables(entries, metrics, fmt, batchChartDefs(entries), CACHED_TABLE_DEFS);
     const stamp = new Date().toISOString().slice(0, 16).replace(/[T:]/g, "-");
 
     if (format === "zip") {

--- a/webui_static/report.js
+++ b/webui_static/report.js
@@ -5,7 +5,7 @@
 (function () {
   "use strict";
 
-  const { esc, fmt, toast, seriesColor, ctxNum, metricsForKeys } = CB;
+  const { esc, fmt, toast, seriesColor, ctxNum, cachedSeriesPoints, metricsForKeys } = CB;
 
   function metricsForEntries(entries) {
     return metricsForKeys(new Set(entries.flatMap(e => e.detail.summary.columns)));
@@ -28,19 +28,33 @@
     catch (e) { return new Set(); }
   }
 
-  // Batch charts: prompt + end-to-end are always there; the pure decode rate
-  // only when the engine recorded it (decode_tps_total from server usage).
+  // Batch charts: prompt + end-to-end are always there; the rest only when
+  // some run in the set actually recorded the field (engines report 0 or
+  // omit it entirely when a metric is unavailable).
   function batchChartDefs(entries) {
     const withBatch = entries.filter(e => e.detail.batch_data && e.detail.batch_data.length);
     if (!withBatch.length) return [];
+    const has = field => withBatch.some(e => e.detail.batch_data.some(b => b[field] != null && b[field] > 0));
     const defs = [
       { key: "batch_prompt", title: "Batch — prompt throughput [tok/s]", field: "prompt_tps" },
       { key: "batch_e2e", title: "Batch — end-to-end gen throughput [tok/s]", field: "generation_tps" },
     ];
-    if (withBatch.some(e => e.detail.batch_data.some(b => b.decode_tps_total != null))) {
+    if (has("decode_tps_total")) {
       defs.push({ key: "batch_decode", title: "Batch — decode throughput [tok/s]", field: "decode_tps_total" });
     }
-    if (withBatch.some(e => e.detail.batch_data.some(b => b.host_memory_gb != null))) {
+    if (has("time_to_first_token")) {
+      defs.push({ key: "batch_ttft", title: "Batch — TTFT [s]", field: "time_to_first_token", seconds: true });
+    }
+    if (has("time_per_output_token")) {
+      defs.push({ key: "batch_tpot", title: "Batch — TPOT [s]", field: "time_per_output_token", seconds: true });
+    }
+    if (has("peak_memory_gb")) {
+      defs.push({ key: "batch_peak_mem", title: "Batch — peak memory [GB]", field: "peak_memory_gb" });
+    }
+    if (has("kv_cache_gb")) {
+      defs.push({ key: "batch_kv", title: "Batch — KV cache [GB]", field: "kv_cache_gb" });
+    }
+    if (has("host_memory_gb")) {
       defs.push({ key: "batch_host_mem", title: "Batch — host RAM [GB]", field: "host_memory_gb" });
     }
     return defs;
@@ -83,8 +97,15 @@
     try {
       for (const metric of metrics) {
         if (only && !only.has(metric.key)) continue;
+        const series = seriesFor(e => e.detail.results.map(r => [ctxNum(r.context_size), r[metric.key]]));
+        for (const e of entries) {
+          const cached = cachedSeriesPoints(e.detail, metric.key);
+          if (cached) series.push({
+            name: `${e.name} · cached`, color: seriesColor(e.slot || 0), dash: true, points: cached,
+          });
+        }
         await render(
-          seriesFor(e => e.detail.results.map(r => [ctxNum(r.context_size), r[metric.key]])),
+          series,
           { height, seconds: metric.seconds, xLabel: "context (tokens ×1000)", yLabel: metric.unit },
           metric.key,
           `${metric.label} across context size [${metric.unit}]`,
@@ -93,8 +114,9 @@
       for (const def of batchChartDefs(entries)) {
         if (only && !only.has(def.key)) continue;
         await render(
-          seriesFor(e => (e.detail.batch_data || []).map(b => [b.batch_size, b[def.field]])),
-          { height: batchHeight, xLabel: "batch size (parallel clients)", yLabel: def.title.match(/\[(.+)\]/)[1], xTickFormat: v => String(v) },
+          // engines write 0 when a batch metric is unavailable — not a data point
+          seriesFor(e => (e.detail.batch_data || []).map(b => [b.batch_size, b[def.field] > 0 ? b[def.field] : null])),
+          { height: batchHeight, seconds: def.seconds, xLabel: "batch size (parallel clients)", yLabel: def.title.match(/\[(.+)\]/)[1], xTickFormat: v => String(v) },
           def.key,
           def.title,
         );
@@ -148,6 +170,8 @@
       files.push({ name: "results.csv", data: encoder.encode(CBExport.buildResultsCsv(entries)) });
       const batchCsv = CBExport.buildBatchCsv(entries);
       if (batchCsv) files.push({ name: "batch_results.csv", data: encoder.encode(batchCsv) });
+      const cachedCsv = CBExport.buildCachedCsv(entries);
+      if (cachedCsv) files.push({ name: "cached_results.csv", data: encoder.encode(cachedCsv) });
       files.push({ name: "comparison.txt", data: encoder.encode(CBExport.buildComparisonTxt(entries, tables, title)) });
       CBExport.download(CBExport.makeZip(files), `${baseName}_${stamp}.zip`);
       return files.length + " files zipped";

--- a/webui_static/report.js
+++ b/webui_static/report.js
@@ -5,10 +5,27 @@
 (function () {
   "use strict";
 
-  const { fmt, toast, seriesColor, ctxNum, metricsForKeys } = CB;
+  const { esc, fmt, toast, seriesColor, ctxNum, metricsForKeys } = CB;
 
   function metricsForEntries(entries) {
     return metricsForKeys(new Set(entries.flatMap(e => e.detail.summary.columns)));
+  }
+
+  // every chart the given runs could produce — the export picker offers these
+  function chartChoices(entries) {
+    return [
+      ...metricsForEntries(entries).map(m => ({ key: m.key, label: `${m.label} (${m.unit})` })),
+      ...batchChartDefs(entries).map(d => ({ key: d.key, label: d.title.replace(/ \[.+\]$/, "") })),
+    ];
+  }
+
+  // deselected chart keys survive across exports (stored as the off-list so
+  // metrics that appear later default to on)
+  const CHART_PREF_KEY = "cb-export-charts-off";
+
+  function excludedCharts() {
+    try { return new Set(JSON.parse(localStorage.getItem(CHART_PREF_KEY) || "[]")); }
+    catch (e) { return new Set(); }
   }
 
   // Batch charts: prompt + end-to-end are always there; the pure decode rate
@@ -34,7 +51,8 @@
   // opts.raw: return class-based SVG markup (themable + interactive in the
   //           HTML report) instead of rasterized canvases.
   async function renderExportCharts(entries, metrics, opts) {
-    const { theme = null, width = 1160, height = 480, batchHeight = 420, legend = true, raw = false } = opts || {};
+    const { theme = null, width = 1160, height = 480, batchHeight = 420, legend = true, raw = false, only = null } =
+      opts || {};
     const stage = document.createElement("div");
     stage.style.cssText = `position:fixed;left:-12000px;top:0;width:${width}px`;
     if (theme === "light") stage.className = "force-light";
@@ -72,6 +90,7 @@
         );
       }
       for (const def of batchChartDefs(entries)) {
+        if (only && !only.has(def.key)) continue;
         await render(
           seriesFor(e => (e.detail.batch_data || []).map(b => [b.batch_size, b[def.field]])),
           { height: batchHeight, xLabel: "batch size (parallel clients)", yLabel: def.title.match(/\[(.+)\]/)[1], xTickFormat: v => String(v) },
@@ -98,29 +117,34 @@
     };
   }
 
-  // format: "zip" | "html" | "pdf"
-  async function exportRuns(entries, format, baseName, title) {
+  // format: "zip" | "html" | "pdf" — `only` (Set of chart keys) limits which
+  // charts are rendered; tables and CSVs always keep the full data
+  async function exportRuns(entries, format, baseName, title, only) {
     const metrics = metricsForEntries(entries);
+    const chartMetrics = only ? metrics.filter(m => only.has(m.key)) : metrics;
     const tables = CBExport.buildTables(entries, metrics, fmt);
     const stamp = new Date().toISOString().slice(0, 16).replace(/[T:]/g, "-");
 
     if (format === "zip") {
       // one compact dashboard PNG instead of a folder of single charts
-      const charts = await renderExportCharts(entries, metrics,
-        { width: 720, height: 330, batchHeight: 300, legend: false });
-      const overview = CBExport.composeOverview({
-        title,
-        // entry names already carry the model, so the sub only adds context
-        runs: entries.map(e => ({
-          name: e.name,
-          color: seriesColor(e.slot || 0),
-          sub: [e.detail.summary.engine, e.detail.summary.machine].filter(Boolean).join(" · "),
-        })),
-        charts,
-        tokens: themeTokens(),
-      });
+      const charts = await renderExportCharts(entries, chartMetrics,
+        { width: 720, height: 330, batchHeight: 300, legend: false, only });
       const encoder = new TextEncoder();
-      const files = [{ name: "overview.png", data: await CBExport.canvasToPngBytes(overview) }];
+      const files = [];
+      if (charts.length) {
+        const overview = CBExport.composeOverview({
+          title,
+          // entry names already carry the model, so the sub only adds context
+          runs: entries.map(e => ({
+            name: e.name,
+            color: seriesColor(e.slot || 0),
+            sub: [e.detail.summary.engine, e.detail.summary.machine].filter(Boolean).join(" · "),
+          })),
+          charts,
+          tokens: themeTokens(),
+        });
+        files.push({ name: "overview.png", data: await CBExport.canvasToPngBytes(overview) });
+      }
       files.push({ name: "results.csv", data: encoder.encode(CBExport.buildResultsCsv(entries)) });
       const batchCsv = CBExport.buildBatchCsv(entries);
       if (batchCsv) files.push({ name: "batch_results.csv", data: encoder.encode(batchCsv) });
@@ -132,8 +156,8 @@
     if (format === "html") {
       // interactive SVG charts: theme with the report's toggle, points show
       // their values on hover/click
-      const charts = await renderExportCharts(entries, metrics,
-        { raw: true, width: 1060, height: 420, batchHeight: 380 });
+      const charts = await renderExportCharts(entries, chartMetrics,
+        { raw: true, width: 1060, height: 420, batchHeight: 380, only });
       const legend = entries.map(e => ({ name: e.name, color: seriesColor(e.slot || 0) }));
       const html = CBExport.buildHtmlReport(title, entries, tables, charts, legend);
       CBExport.download(new Blob([html], { type: "text/html" }), `${baseName}_${stamp}.html`);
@@ -141,7 +165,7 @@
     }
 
     // pdf — always the print-friendly light style
-    const charts = await renderExportCharts(entries, metrics, { theme: "light" });
+    const charts = await renderExportCharts(entries, chartMetrics, { theme: "light", only });
     const chartData = [];
     for (const c of charts) chartData.push({ title: c.title, jpeg: await CBExport.canvasToJpeg(c.canvas) });
     const pdf = CBExport.buildPdfReport(title, entries, tables, chartData);
@@ -149,24 +173,72 @@
     return "PDF report saved";
   }
 
+  async function runExport(group, format, entries, baseName, getTitle, only) {
+    const btn = group.querySelector(`[data-export="${format}"]`);
+    group.querySelectorAll(".btn").forEach(b => { b.disabled = true; });
+    const original = btn.textContent;
+    btn.textContent = "…";
+    try {
+      const message = await exportRuns(entries, format, baseName, getTitle(entries), only);
+      toast("Export ready — " + message + ".");
+    } catch (e) {
+      toast("Export failed: " + e.message, true);
+    } finally {
+      btn.textContent = original;
+      group.querySelectorAll(".btn").forEach(b => { b.disabled = false; });
+    }
+  }
+
+  // small popover under the clicked export button: pick which charts go in
+  function openChartPicker(group, format, entries, baseName, getTitle) {
+    const choices = chartChoices(entries);
+    const off = excludedCharts();
+    const pop = document.createElement("div");
+    pop.className = "export-pop";
+    pop.dataset.format = format;
+    pop.innerHTML = `
+      <div class="pop-title">Charts in the ${esc(format.toUpperCase())} export</div>
+      <div class="pop-list">${choices.map(c => `
+        <label class="check"><input type="checkbox" value="${esc(c.key)}" ${off.has(c.key) ? "" : "checked"}>
+          ${esc(c.label)}</label>`).join("")}
+      </div>
+      <div class="pop-actions">
+        <button class="btn small" data-pick="all">All</button>
+        <button class="btn small" data-pick="none">None</button>
+        <span style="flex:1"></span>
+        <button class="btn small primary" data-go>Export</button>
+      </div>`;
+    group.appendChild(pop);
+    const boxes = () => [...pop.querySelectorAll("input[type=checkbox]")];
+    pop.querySelector('[data-pick="all"]').addEventListener("click", () => boxes().forEach(b => { b.checked = true; }));
+    pop.querySelector('[data-pick="none"]').addEventListener("click", () => boxes().forEach(b => { b.checked = false; }));
+    const onOutside = e => { if (!pop.contains(e.target) && !group.contains(e.target)) pop.close(); };
+    pop.close = () => { pop.remove(); document.removeEventListener("mousedown", onOutside); };
+    document.addEventListener("mousedown", onOutside);
+    pop.querySelector("[data-go]").addEventListener("click", async () => {
+      const selected = new Set(boxes().filter(b => b.checked).map(b => b.value));
+      // persist per chart key, keeping off-entries of charts not offered here
+      choices.forEach(c => (selected.has(c.key) ? off.delete(c.key) : off.add(c.key)));
+      localStorage.setItem(CHART_PREF_KEY, JSON.stringify([...off]));
+      pop.close();
+      await runExport(group, format, entries, baseName, getTitle, selected);
+    });
+  }
+
   function wireExportGroup(container, getEntries, baseName, getTitle) {
     container.querySelectorAll("[data-export]").forEach(btn => {
       btn.addEventListener("click", async () => {
         const group = btn.closest(".export-group");
-        group.querySelectorAll(".btn").forEach(b => { b.disabled = true; });
-        const original = btn.textContent;
-        btn.textContent = "…";
-        try {
-          const entries = await getEntries();
-          if (!entries.length) { toast("Nothing selected to export.", true); return; }
-          const message = await exportRuns(entries, btn.dataset.export, baseName, getTitle(entries));
-          toast("Export ready — " + message + ".");
-        } catch (e) {
-          toast("Export failed: " + e.message, true);
-        } finally {
-          btn.textContent = original;
-          group.querySelectorAll(".btn").forEach(b => { b.disabled = false; });
+        const open = group.querySelector(".export-pop");
+        if (open) {
+          const sameFormat = open.dataset.format === btn.dataset.export;
+          open.close();
+          if (sameFormat) return; // second click on the same button toggles the picker away
         }
+        let entries;
+        try { entries = await getEntries(); } catch (e) { toast(e.message, true); return; }
+        if (!entries.length) { toast("Nothing selected to export.", true); return; }
+        openChartPicker(group, btn.dataset.export, entries, baseName, getTitle);
       });
     });
   }

--- a/webui_static/report.js
+++ b/webui_static/report.js
@@ -73,8 +73,10 @@
   // opts.raw: return class-based SVG markup (themable + interactive in the
   //           HTML report) instead of rasterized canvases.
   async function renderExportCharts(entries, metrics, opts) {
-    const { theme = null, width = 1160, height = 480, batchHeight = 420, legend = true, raw = false, only = null } =
-      opts || {};
+    const {
+      theme = null, width = 1160, height = 480, batchHeight = 420,
+      legend = true, raw = false, only = null, pointLabels = false,
+    } = opts || {};
     const stage = document.createElement("div");
     stage.style.cssText = `position:fixed;left:-12000px;top:0;width:${width}px`;
     if (theme === "light") stage.className = "force-light";
@@ -90,7 +92,7 @@
       if (!series.length) return;
       stage.innerHTML = "";
       Charts.lineChart(stage, {
-        series, logX: true, width, legend: false,
+        series, logX: true, width, legend: false, pointLabels,
         svgTitle: raw ? undefined : title,
         svgLegend: raw ? false : legend,
         ...chartOpts,
@@ -114,7 +116,8 @@
         }
         await render(
           series,
-          { height, seconds: metric.seconds, xLabel: "context (tokens ×1000)", yLabel: metric.unit },
+          // no x-axis label: the »0.5k / 1k / …« ticks say it all
+          { height, seconds: metric.seconds, yLabel: metric.unit },
           metric.key,
           `${metric.label} across context size [${metric.unit}]`,
           metric.desc,
@@ -158,9 +161,10 @@
     const stamp = new Date().toISOString().slice(0, 16).replace(/[T:]/g, "-");
 
     if (format === "zip") {
-      // one compact dashboard PNG instead of a folder of single charts
+      // one compact dashboard PNG instead of a folder of single charts;
+      // value labels at the points because a PNG has no hover tooltip
       const charts = await renderExportCharts(entries, metrics,
-        { width: 720, height: 330, batchHeight: 300, legend: false, only });
+        { width: 720, height: 330, batchHeight: 300, legend: false, only, pointLabels: true });
       const encoder = new TextEncoder();
       const files = [];
       if (charts.length) {
@@ -200,8 +204,9 @@
       return "HTML report saved";
     }
 
-    // pdf — always the print-friendly light style
-    const charts = await renderExportCharts(entries, metrics, { theme: "light", only });
+    // pdf — always the print-friendly light style; value labels because
+    // print has no hover tooltip either
+    const charts = await renderExportCharts(entries, metrics, { theme: "light", only, pointLabels: true });
     const chartData = [];
     for (const c of charts) chartData.push({ title: c.title, jpeg: await CBExport.canvasToJpeg(c.canvas) });
     const pdf = CBExport.buildPdfReport(title, entries, tables, chartData);

--- a/webui_static/report.js
+++ b/webui_static/report.js
@@ -167,10 +167,12 @@
         const overview = CBExport.composeOverview({
           title,
           // entry names already carry the model, so the sub only adds context
+          // no local machine info here: for endpoint runs the inference ran
+          // elsewhere — the endpoint name is the machine that matters
           runs: entries.map(e => ({
             name: e.name,
             color: seriesColor(e.slot || 0),
-            sub: [e.detail.summary.engine, e.detail.summary.machine].filter(Boolean).join(" · "),
+            sub: [e.detail.summary.engine, e.detail.summary.endpoint].filter(Boolean).join(" · "),
           })),
           charts,
           tokens: themeTokens(),

--- a/webui_static/report.js
+++ b/webui_static/report.js
@@ -14,8 +14,8 @@
   // every chart the given runs could produce — the export picker offers these
   function chartChoices(entries) {
     return [
-      ...metricsForEntries(entries).map(m => ({ key: m.key, label: `${m.label} (${m.unit})` })),
-      ...batchChartDefs(entries).map(d => ({ key: d.key, label: d.title.replace(/ \[.+\]$/, "") })),
+      ...metricsForEntries(entries).map(m => ({ key: m.key, label: `${m.label} (${m.unit})`, desc: m.desc })),
+      ...batchChartDefs(entries).map(d => ({ key: d.key, label: d.title.replace(/ \[.+\]$/, ""), desc: d.desc })),
     ];
   }
 
@@ -36,26 +36,34 @@
     if (!withBatch.length) return [];
     const has = field => withBatch.some(e => e.detail.batch_data.some(b => b[field] != null && b[field] > 0));
     const defs = [
-      { key: "batch_prompt", title: "Batch — prompt throughput [tok/s]", field: "prompt_tps" },
-      { key: "batch_e2e", title: "Batch — end-to-end gen throughput [tok/s]", field: "generation_tps" },
+      { key: "batch_prompt", title: "Batch — prompt throughput [tok/s]", field: "prompt_tps",
+        desc: "Prompt (prefill) throughput summed across N parallel clients. Higher is better." },
+      { key: "batch_e2e", title: "Batch — end-to-end gen throughput [tok/s]", field: "generation_tps",
+        desc: "End-to-end generation throughput: generated tokens ÷ total wall time including the prompt phase, summed across clients." },
     ];
     if (has("decode_tps_total")) {
-      defs.push({ key: "batch_decode", title: "Batch — decode throughput [tok/s]", field: "decode_tps_total" });
+      defs.push({ key: "batch_decode", title: "Batch — decode throughput [tok/s]", field: "decode_tps_total",
+        desc: "Pure generation rate the server reported, summed across clients — prompt phase excluded." });
     }
     if (has("time_to_first_token")) {
-      defs.push({ key: "batch_ttft", title: "Batch — TTFT [s]", field: "time_to_first_token", seconds: true });
+      defs.push({ key: "batch_ttft", title: "Batch — TTFT [s]", field: "time_to_first_token", seconds: true,
+        desc: "Time to first token at this concurrency — the wait each client sees under load. Lower is better." });
     }
     if (has("time_per_output_token")) {
-      defs.push({ key: "batch_tpot", title: "Batch — TPOT [s]", field: "time_per_output_token", seconds: true });
+      defs.push({ key: "batch_tpot", title: "Batch — TPOT [s]", field: "time_per_output_token", seconds: true,
+        desc: "Average gap between two generated tokens at this concurrency. Lower is better." });
     }
     if (has("peak_memory_gb")) {
-      defs.push({ key: "batch_peak_mem", title: "Batch — peak memory [GB]", field: "peak_memory_gb" });
+      defs.push({ key: "batch_peak_mem", title: "Batch — peak memory [GB]", field: "peak_memory_gb",
+        desc: "Peak accelerator/unified memory while serving N clients in parallel." });
     }
     if (has("kv_cache_gb")) {
-      defs.push({ key: "batch_kv", title: "Batch — KV cache [GB]", field: "kv_cache_gb" });
+      defs.push({ key: "batch_kv", title: "Batch — KV cache [GB]", field: "kv_cache_gb",
+        desc: "Key-value-cache size with N concurrent sequences — grows with concurrency." });
     }
     if (has("host_memory_gb")) {
-      defs.push({ key: "batch_host_mem", title: "Batch — host RAM [GB]", field: "host_memory_gb" });
+      defs.push({ key: "batch_host_mem", title: "Batch — host RAM [GB]", field: "host_memory_gb",
+        desc: "Resident memory of the server process while serving N clients in parallel." });
     }
     return defs;
   }
@@ -78,7 +86,7 @@
       .map(e => ({ name: e.name, color: seriesColor(e.slot || 0), points: getPoints(e) }))
       .filter(s => s.points.some(p => p[1] != null && isFinite(p[1])));
 
-    const render = async (series, chartOpts, key, title) => {
+    const render = async (series, chartOpts, key, title, desc) => {
       if (!series.length) return;
       stage.innerHTML = "";
       Charts.lineChart(stage, {
@@ -90,8 +98,8 @@
       const svg = stage.querySelector("svg");
       if (!svg) return;
       charts.push(raw
-        ? { key, title, svg: svg.outerHTML }
-        : { key, title, canvas: await CBExport.svgToCanvas(svg, 2, surface()) });
+        ? { key, title, desc, svg: svg.outerHTML }
+        : { key, title, desc, canvas: await CBExport.svgToCanvas(svg, 2, surface()) });
     };
 
     try {
@@ -109,6 +117,7 @@
           { height, seconds: metric.seconds, xLabel: "context (tokens ×1000)", yLabel: metric.unit },
           metric.key,
           `${metric.label} across context size [${metric.unit}]`,
+          metric.desc,
         );
       }
       for (const def of batchChartDefs(entries)) {
@@ -119,6 +128,7 @@
           { height: batchHeight, seconds: def.seconds, xLabel: "batch size (parallel clients)", yLabel: def.title.match(/\[(.+)\]/)[1], xTickFormat: v => String(v) },
           def.key,
           def.title,
+          def.desc,
         );
       }
     } finally {
@@ -144,7 +154,7 @@
   // charts are rendered; tables and CSVs always keep the full data
   async function exportRuns(entries, format, baseName, title, only) {
     const metrics = metricsForEntries(entries);
-    const tables = CBExport.buildTables(entries, metrics, fmt);
+    const tables = CBExport.buildTables(entries, metrics, fmt, batchChartDefs(entries));
     const stamp = new Date().toISOString().slice(0, 16).replace(/[T:]/g, "-");
 
     if (format === "zip") {
@@ -223,7 +233,7 @@
     pop.innerHTML = `
       <div class="pop-title">Charts in the ${esc(format.toUpperCase())} export</div>
       <div class="pop-list">${choices.map(c => `
-        <label class="check"><input type="checkbox" value="${esc(c.key)}" ${off.has(c.key) ? "" : "checked"}>
+        <label class="check" title="${esc(c.desc || "")}"><input type="checkbox" value="${esc(c.key)}" ${off.has(c.key) ? "" : "checked"}>
           ${esc(c.label)}</label>`).join("")}
       </div>
       <div class="pop-actions">

--- a/webui_static/styles.css
+++ b/webui_static/styles.css
@@ -505,6 +505,27 @@ table.tbl { border-collapse: collapse; width: 100%; font-size: 12.5px; }
 .legend-item { display: flex; align-items: center; gap: 7px; font-size: 12px; color: var(--ink-2); }
 .legend-swatch { width: 14px; height: 3px; border-radius: 2px; }
 .chart-title { font-size: 13px; font-weight: 600; margin: 2px 0 12px; }
+
+/* hoverable »what does this metric mean« marker */
+.qmark {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 15px; height: 15px; margin-left: 7px; vertical-align: 1px;
+  border: 1px solid var(--axis); border-radius: 50%;
+  color: var(--muted); font: 600 9.5px/1 var(--mono);
+  cursor: help; position: relative;
+}
+.qmark:hover, .qmark:focus-visible { color: var(--ink); border-color: var(--muted); outline: none; }
+.qmark::after {
+  content: attr(data-tip);
+  position: absolute; left: -20px; top: calc(100% + 8px);
+  width: 300px; max-width: 60vw;
+  background: var(--raised); border: 1px solid var(--hairline); border-radius: 8px;
+  padding: 8px 11px; font: 400 12px/1.5 var(--sans, system-ui, sans-serif); color: var(--ink-2);
+  text-align: left; text-transform: none; letter-spacing: normal; white-space: normal;
+  box-shadow: 0 10px 34px rgba(0, 0, 0, 0.35); z-index: 80;
+  opacity: 0; visibility: hidden; transition: opacity 120ms ease; pointer-events: none;
+}
+.qmark:hover::after, .qmark:focus::after { opacity: 1; visibility: visible; }
 .chart-empty { color: var(--muted); font-size: 12.5px; padding: 30px 0; text-align: center; }
 
 /* ---------- endpoints ---------- */

--- a/webui_static/styles.css
+++ b/webui_static/styles.css
@@ -592,7 +592,7 @@ table.tbl { border-collapse: collapse; width: 100%; font-size: 12.5px; }
 .model-row { display: flex; gap: 6px; }
 .model-row select, .model-row input { flex: 1; min-width: 0; }
 .model-row .btn { flex: none; padding-left: 9px; padding-right: 9px; }
-.export-group { display: flex; gap: 0; align-items: center; }
+.export-group { display: flex; gap: 0; align-items: center; position: relative; }
 .export-group .export-label {
   font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
   text-transform: uppercase; color: var(--muted); margin-right: 8px;
@@ -600,3 +600,22 @@ table.tbl { border-collapse: collapse; width: 100%; font-size: 12.5px; }
 .export-group .btn { border-radius: 0; margin-left: -1px; }
 .export-group .btn:first-of-type { border-radius: 8px 0 0 8px; margin-left: 0; }
 .export-group .btn:last-of-type { border-radius: 0 8px 8px 0; }
+
+/* chart picker popover under the clicked export button */
+.export-pop {
+  position: absolute; top: calc(100% + 8px); right: 0; z-index: 70;
+  min-width: 260px; padding: 12px 14px; text-align: left; cursor: default;
+  background: var(--surface); border: 1px solid var(--hairline); border-radius: 10px;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.35);
+}
+.export-pop .pop-title {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--muted); margin-bottom: 10px; white-space: nowrap;
+}
+.export-pop .pop-list {
+  display: flex; flex-direction: column; gap: 7px;
+  max-height: 280px; overflow: auto; margin-bottom: 12px;
+}
+.export-pop .pop-list .check { white-space: nowrap; }
+.export-pop .pop-actions { display: flex; gap: 6px; align-items: center; }
+.export-pop .btn { border-radius: 8px; margin-left: 0; }

--- a/webui_static/styles.css
+++ b/webui_static/styles.css
@@ -377,6 +377,11 @@ table.tbl { border-collapse: collapse; width: 100%; font-size: 12.5px; }
   white-space: nowrap;
 }
 .tbl tbody tr:hover { background: var(--raised); }
+.tbl tr.delta td {
+  border-top: 2px solid var(--axis);
+  color: var(--ink-2);
+  font-family: var(--mono); font-size: 11.5px;
+}
 
 /* ---------- results list ---------- */
 .results-toolbar { display: flex; gap: 10px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
@@ -460,6 +465,12 @@ table.tbl { border-collapse: collapse; width: 100%; font-size: 12.5px; }
 }
 .metric-tab.active .unit { color: var(--accent); }
 .chart-controls { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; margin-bottom: 8px; }
+.chart-controls select {
+  background: var(--surface); color: var(--ink);
+  border: 1px solid var(--hairline); border-radius: 8px;
+  padding: 4px 8px; font-size: 12.5px; max-width: 260px;
+}
+.chart-controls select:hover { border-color: var(--border); }
 .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 @media (max-width: 1250px) { .chart-grid { grid-template-columns: 1fr; } }
 

--- a/webui_static/styles.css
+++ b/webui_static/styles.css
@@ -480,6 +480,11 @@ table.tbl { border-collapse: collapse; width: 100%; font-size: 12.5px; }
 .viz .gridline { stroke: var(--grid); stroke-width: 1; }
 .viz .axisline { stroke: var(--axis); stroke-width: 1; }
 .viz .tick-label { fill: var(--muted); font-family: var(--mono); font-size: 10px; }
+.viz .point-label {
+  font-family: var(--mono); font-size: 8.5px; font-weight: 600;
+  /* surface-colored halo keeps the value readable where lines cross it */
+  paint-order: stroke; stroke: var(--surface); stroke-width: 2.5px;
+}
 .viz .axis-title { fill: var(--muted); font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; }
 .viz .series-line { fill: none; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
 .viz .series-dot { stroke: var(--surface); stroke-width: 2; }

--- a/webui_static/view-compare.js
+++ b/webui_static/view-compare.js
@@ -208,7 +208,7 @@
       const series = await compareSeriesFor(metric.key);
       Charts.lineChart(document.getElementById("cmpHero"), {
         series, logX: true, height: 440, seconds: secondsFor(metric),
-        xLabel: "context (tokens ×1000)", yLabel: unitFor(metric),
+        xLabel: "context", yLabel: unitFor(metric),
       });
       renderCompareTable(series, { ...metric, seconds: secondsFor(metric) });
     }

--- a/webui_static/view-compare.js
+++ b/webui_static/view-compare.js
@@ -5,7 +5,7 @@
   "use strict";
 
   const {
-    state, esc, fmt, seriesColor, ctxNum, fmtDate, pageHead,
+    state, esc, fmt, seriesColor, ctxNum, cachedSeriesPoints, fmtDate, pageHead,
     resultName, resultSubtitle, seriesLabel, matchesFilter, metricsForKeys,
     ensureResults, ensureDetail, toggleCompare,
   } = CB;
@@ -26,6 +26,8 @@
         <div class="metric-tabs" id="cmpTabs"></div>
         <div class="chart-controls">
           <label class="check"><input type="checkbox" id="cmpGrid" ${state.compare.grid ? "checked" : ""}> All metrics grid</label>
+          <label class="check" id="cmpBaselineWrap" hidden>Relative to
+            <select id="cmpBaseline"></select></label>
           <span style="flex:1"></span>
           ${CB.report.exportGroupHtml()}
         </div>
@@ -40,6 +42,10 @@
     document.getElementById("cmpFilter").addEventListener("input", renderPickList);
     document.getElementById("cmpGrid").addEventListener("change", e => {
       state.compare.grid = e.target.checked;
+      renderCompareCharts();
+    });
+    document.getElementById("cmpBaseline").addEventListener("change", e => {
+      state.compare.baseline = e.target.value || null;
       renderCompareCharts();
     });
     CB.report.wireExportGroup(root, compareEntries, "context-bench-comparison",
@@ -98,19 +104,41 @@
     });
   }
 
+  function baselineFolder() {
+    const folder = state.compare.baseline;
+    return folder && state.compare.slots.has(folder) ? folder : null;
+  }
+
   async function compareSeriesFor(metricKey) {
     const series = [];
     for (const [folder, slot] of state.compare.slots.entries()) {
       let detail;
       try { detail = await ensureDetail(folder); } catch (e) { continue; }
+      const name = seriesLabel(detail.summary);
       series.push({
-        name: seriesLabel(detail.summary),
+        name,
         color: seriesColor(slot),
-        slot,
+        slot, folder,
         points: detail.results.map(r => [ctxNum(r.context_size), r[metricKey]]),
       });
+      const cached = cachedSeriesPoints(detail, metricKey);
+      if (cached) series.push({
+        name: `${name} · cached`, color: seriesColor(slot), slot, folder,
+        dash: true, isCached: true, points: cached,
+      });
     }
-    series.sort((a, b) => a.slot - b.slot);
+    series.sort((a, b) => a.slot - b.slot || (a.isCached ? 1 : 0) - (b.isCached ? 1 : 0));
+
+    // baseline mode: every point becomes a percentage of the baseline run's
+    // (cold) value at the same context size — the baseline stays flat at 100
+    const base = series.find(s => s.folder === baselineFolder() && !s.isCached);
+    if (base) {
+      const baseAt = new Map(base.points.filter(p => p[1] != null && isFinite(p[1]) && p[1] > 0));
+      for (const s of series) {
+        s.points = s.points.map(([x, y]) =>
+          [x, y != null && isFinite(y) && baseAt.has(x) ? (y / baseAt.get(x)) * 100 : null]);
+      }
+    }
     return series;
   }
 
@@ -148,37 +176,59 @@
         renderCompareCharts();
       }));
 
+    syncBaselinePicker();
+    const relative = !!baselineFolder();
+    const unitFor = metric => (relative ? "% of baseline" : metric.unit);
+    const secondsFor = metric => (relative ? false : metric.seconds);
+
     if (state.compare.grid) {
       container.innerHTML = `<div class="chart-grid" id="cmpGridWrap"></div>${batchSectionHtml()}`;
       const wrap = document.getElementById("cmpGridWrap");
       for (const metric of metrics) {
         const panel = document.createElement("div");
         panel.className = "panel";
-        panel.innerHTML = `<div class="chart-title">${esc(metric.label)} <span class="unit">${esc(metric.unit)}</span></div><div></div>`;
+        panel.innerHTML = `<div class="chart-title">${esc(metric.label)} <span class="unit">${esc(unitFor(metric))}</span></div><div></div>`;
         wrap.appendChild(panel);
         const series = await compareSeriesFor(metric.key);
         Charts.lineChart(panel.lastElementChild, {
-          series, logX: true, height: 230, seconds: metric.seconds,
-          xLabel: "context", yLabel: metric.unit,
+          series, logX: true, height: 230, seconds: secondsFor(metric),
+          xLabel: "context", yLabel: unitFor(metric),
         });
       }
     } else {
       const metric = metrics.find(m => m.key === state.compare.metric) || metrics[0];
       if (!metric) { container.innerHTML = `<div class="empty">No comparable metrics.</div>`; return; }
       container.innerHTML = `<div class="panel">
-          <div class="chart-title">${esc(metric.label)} across context size <span class="unit">${esc(metric.unit)}</span></div>
+          <div class="chart-title">${esc(metric.label)} across context size <span class="unit">${esc(unitFor(metric))}</span></div>
           <div id="cmpHero"></div>
         </div>
         <div class="panel"><div class="chart-title">Values</div><div class="tbl-wrap" id="cmpTable"></div></div>
         ${batchSectionHtml()}`;
       const series = await compareSeriesFor(metric.key);
       Charts.lineChart(document.getElementById("cmpHero"), {
-        series, logX: true, height: 440, seconds: metric.seconds,
-        xLabel: "context (tokens ×1000)", yLabel: metric.unit,
+        series, logX: true, height: 440, seconds: secondsFor(metric),
+        xLabel: "context (tokens ×1000)", yLabel: unitFor(metric),
       });
-      renderCompareTable(series, metric);
+      renderCompareTable(series, { ...metric, seconds: secondsFor(metric) });
     }
     await renderBatchCharts();
+  }
+
+  // the »Relative to« picker lists the selected runs; it only shows for 2+
+  function syncBaselinePicker() {
+    const wrap = document.getElementById("cmpBaselineWrap");
+    const select = document.getElementById("cmpBaseline");
+    if (!wrap || !select) return;
+    if (state.compare.baseline && !state.compare.slots.has(state.compare.baseline)) {
+      state.compare.baseline = null;
+    }
+    const runs = [...state.compare.slots.entries()].sort((a, b) => a[1] - b[1]).map(([folder]) => {
+      const summary = state.results.find(r => r.folder === folder);
+      return { folder, name: summary ? seriesLabel(summary) : folder };
+    });
+    wrap.hidden = runs.length < 2;
+    select.innerHTML = `<option value="">absolute values</option>` + runs.map(r =>
+      `<option value="${esc(r.folder)}" ${r.folder === state.compare.baseline ? "selected" : ""}>${esc(r.name)}</option>`).join("");
   }
 
   function batchSectionHtml() {
@@ -207,7 +257,8 @@
       const series = batchEntries.map(e => ({
         name: e.name,
         color: seriesColor(e.slot),
-        points: e.detail.batch_data.map(b => [b.batch_size, b[def.field]]),
+        // engines write 0 when a batch metric is unavailable — not a data point
+        points: e.detail.batch_data.map(b => [b.batch_size, b[def.field] > 0 ? b[def.field] : null]),
       })).filter(s => s.points.some(p => p[1] != null && isFinite(p[1])));
       if (!series.length) continue;
       const panel = document.createElement("div");
@@ -216,7 +267,7 @@
         <span class="unit">${esc(unit)}</span></div><div></div>`;
       wrap.appendChild(panel);
       Charts.lineChart(panel.lastElementChild, {
-        series, logX: true, height: 240,
+        series, logX: true, height: 240, seconds: def.seconds,
         xLabel: "batch size (parallel clients)", yLabel: unit,
         xTickFormat: v => String(v),
       });
@@ -227,13 +278,25 @@
     const node = document.getElementById("cmpTable");
     if (!node) return;
     const xs = [...new Set(series.flatMap(s => s.points.map(p => p[0])))].sort((a, b) => a - b);
+    // context degradation: value at the largest context as % of the smallest —
+    // how much throughput a setup retains (or how much slower time metrics get)
+    const firstX = xs[0];
+    const lastX = xs[xs.length - 1];
+    const deltaRow = xs.length < 2 ? "" : `<tr class="delta"
+      title="Value at the largest context as a percentage of the smallest — retention for throughput metrics, slowdown for time metrics.">
+      <td>${esc(lastX)}k / ${esc(firstX)}k</td>${series.map(s => {
+        const at = x => s.points.find(pt => pt[0] === x && pt[1] != null && isFinite(pt[1]));
+        const first = at(firstX);
+        const last = at(lastX);
+        return `<td>${first && last && first[1] > 0 ? ((last[1] / first[1]) * 100).toFixed(0) + "%" : "–"}</td>`;
+      }).join("")}</tr>`;
     node.innerHTML = `<table class="tbl">
       <thead><tr><th>context</th>${series.map(s =>
         `<th><span class="legend-swatch" style="background:${s.color};display:inline-block;vertical-align:middle;margin-right:5px"></span>${esc(s.name)}</th>`).join("")}</tr></thead>
       <tbody>${xs.map(x => `<tr><td>${esc(x)}k</td>${series.map(s => {
         const p = s.points.find(pt => pt[0] === x && pt[1] != null);
         return `<td>${p ? esc(fmt(p[1], { seconds: metric.seconds })) : "–"}</td>`;
-      }).join("")}</tr>`).join("")}</tbody>
+      }).join("")}</tr>`).join("")}${deltaRow}</tbody>
     </table>`;
   }
 

--- a/webui_static/view-compare.js
+++ b/webui_static/view-compare.js
@@ -5,7 +5,7 @@
   "use strict";
 
   const {
-    state, esc, fmt, seriesColor, ctxNum, cachedSeriesPoints, fmtDate, pageHead,
+    state, esc, fmt, seriesColor, ctxNum, cachedSeriesPoints, qmarkHtml, fmtDate, pageHead,
     resultName, resultSubtitle, seriesLabel, matchesFilter, metricsForKeys,
     ensureResults, ensureDetail, toggleCompare,
   } = CB;
@@ -26,7 +26,7 @@
         <div class="metric-tabs" id="cmpTabs"></div>
         <div class="chart-controls">
           <label class="check"><input type="checkbox" id="cmpGrid" ${state.compare.grid ? "checked" : ""}> All metrics grid</label>
-          <label class="check" id="cmpBaselineWrap" hidden>Relative to
+          <label class="check" id="cmpBaselineWrap" style="display:none">Relative to
             <select id="cmpBaseline"></select></label>
           <span style="flex:1"></span>
           ${CB.report.exportGroupHtml()}
@@ -168,7 +168,8 @@
       state.compare.metric = metrics[0].key;
     }
     tabs.innerHTML = metrics.map(m =>
-      `<button class="metric-tab ${m.key === state.compare.metric ? "active" : ""}" data-metric="${esc(m.key)}">
+      `<button class="metric-tab ${m.key === state.compare.metric ? "active" : ""}" data-metric="${esc(m.key)}"
+        title="${esc(m.desc || "")}">
         ${esc(m.label)} <span class="unit">${esc(m.unit)}</span></button>`).join("");
     tabs.querySelectorAll(".metric-tab").forEach(btn =>
       btn.addEventListener("click", () => {
@@ -187,7 +188,7 @@
       for (const metric of metrics) {
         const panel = document.createElement("div");
         panel.className = "panel";
-        panel.innerHTML = `<div class="chart-title">${esc(metric.label)} <span class="unit">${esc(unitFor(metric))}</span></div><div></div>`;
+        panel.innerHTML = `<div class="chart-title">${esc(metric.label)} <span class="unit">${esc(unitFor(metric))}</span>${qmarkHtml(metric.desc)}</div><div></div>`;
         wrap.appendChild(panel);
         const series = await compareSeriesFor(metric.key);
         Charts.lineChart(panel.lastElementChild, {
@@ -199,7 +200,7 @@
       const metric = metrics.find(m => m.key === state.compare.metric) || metrics[0];
       if (!metric) { container.innerHTML = `<div class="empty">No comparable metrics.</div>`; return; }
       container.innerHTML = `<div class="panel">
-          <div class="chart-title">${esc(metric.label)} across context size <span class="unit">${esc(unitFor(metric))}</span></div>
+          <div class="chart-title">${esc(metric.label)} across context size <span class="unit">${esc(unitFor(metric))}</span>${qmarkHtml(metric.desc)}</div>
           <div id="cmpHero"></div>
         </div>
         <div class="panel"><div class="chart-title">Values</div><div class="tbl-wrap" id="cmpTable"></div></div>
@@ -226,7 +227,8 @@
       const summary = state.results.find(r => r.folder === folder);
       return { folder, name: summary ? seriesLabel(summary) : folder };
     });
-    wrap.hidden = runs.length < 2;
+    // .check sets display:flex, which would override the hidden attribute
+    wrap.style.display = runs.length < 2 ? "none" : "";
     select.innerHTML = `<option value="">absolute values</option>` + runs.map(r =>
       `<option value="${esc(r.folder)}" ${r.folder === state.compare.baseline ? "selected" : ""}>${esc(r.name)}</option>`).join("");
   }
@@ -264,7 +266,7 @@
       const panel = document.createElement("div");
       panel.className = "panel";
       panel.innerHTML = `<div class="chart-title">${esc(def.title.replace(/ \[.+\]$/, ""))}
-        <span class="unit">${esc(unit)}</span></div><div></div>`;
+        <span class="unit">${esc(unit)}</span>${qmarkHtml(def.desc)}</div><div></div>`;
       wrap.appendChild(panel);
       Charts.lineChart(panel.lastElementChild, {
         series, logX: true, height: 240, seconds: def.seconds,

--- a/webui_static/view-compare.js
+++ b/webui_static/view-compare.js
@@ -255,7 +255,7 @@
     const batchEntries = entries.filter(e => e.detail.batch_data && e.detail.batch_data.length);
     wrap.innerHTML = "";
     for (const def of defs) {
-      const unit = (def.title.match(/\[(.+)\]/) || [])[1] || "";
+      const unit = def.unit || "";
       const series = batchEntries.map(e => ({
         name: e.name,
         color: seriesColor(e.slot),
@@ -265,7 +265,7 @@
       if (!series.length) continue;
       const panel = document.createElement("div");
       panel.className = "panel";
-      panel.innerHTML = `<div class="chart-title">${esc(def.title.replace(/ \[.+\]$/, ""))}
+      panel.innerHTML = `<div class="chart-title">${esc(def.title)}
         <span class="unit">${esc(unit)}</span>${qmarkHtml(def.desc)}</div><div></div>`;
       wrap.appendChild(panel);
       Charts.lineChart(panel.lastElementChild, {

--- a/webui_static/view-endpoints.js
+++ b/webui_static/view-endpoints.js
@@ -215,11 +215,14 @@
         notes: modal.querySelector("#epNotes").value,
       };
       try {
-        if (endpoint) await api(`/api/endpoints/${encodeURIComponent(endpoint.id)}`, { method: "PUT", body: payload });
-        else await api("/api/endpoints", { body: payload });
+        const saved = endpoint
+          ? await api(`/api/endpoints/${encodeURIComponent(endpoint.id)}`, { method: "PUT", body: payload })
+          : await api("/api/endpoints", { body: payload });
         closeModal();
         renderEndpointsView();
-        toast("Endpoint saved.");
+        toast(saved.base_url_corrected
+          ? `Endpoint saved — appended /v1 to the base URL (the server answers there): ${saved.base_url}`
+          : "Endpoint saved.");
       } catch (e) { toast(e.message, true); }
     });
   }

--- a/webui_static/view-results.js
+++ b/webui_static/view-results.js
@@ -5,7 +5,7 @@
   "use strict";
 
   const {
-    state, METRICS, esc, fmt, api, toast, seriesColor, ctxNum, cachedSeriesPoints, fmtDate,
+    state, METRICS, esc, fmt, api, toast, seriesColor, ctxNum, cachedSeriesPoints, qmarkHtml, fmtDate,
     pageHead, resultName, resultSubtitle, seriesLabel, matchesFilter,
     ensureResults, ensureDetail, toggleCompare, openModal,
   } = CB;
@@ -137,7 +137,7 @@
     const chartPanels = chartKeys.map(key => {
       const metric = METRICS.find(m => m.key === key) || { label: key, unit: "" };
       return `<div><div class="chart-title">${esc(metric.label)}
-        ${metric.unit ? `<span class="unit">${esc(metric.unit)}</span>` : ""}</div>
+        ${metric.unit ? `<span class="unit">${esc(metric.unit)}</span>` : ""}${qmarkHtml(metric.desc)}</div>
         <div data-chart="${esc(key)}"></div></div>`;
     }).join("");
 

--- a/webui_static/view-results.js
+++ b/webui_static/view-results.js
@@ -5,7 +5,7 @@
   "use strict";
 
   const {
-    state, METRICS, esc, fmt, api, toast, seriesColor, ctxNum, fmtDate,
+    state, METRICS, esc, fmt, api, toast, seriesColor, ctxNum, cachedSeriesPoints, fmtDate,
     pageHead, resultName, resultSubtitle, seriesLabel, matchesFilter,
     ensureResults, ensureDetail, toggleCompare, openModal,
   } = CB;
@@ -154,18 +154,49 @@
         <tbody>${rows.map(r => `<tr>${cols.map(c =>
           `<td>${c === "context_size" ? esc(r[c]) : esc(fmt(r[c], { seconds: /time|ttft|tpot/.test(c) }))}</td>`).join("")}</tr>`).join("")}
         </tbody></table></div>
+      ${detail.cached_results && detail.cached_results.length ? (() => {
+        const cachedRows = detail.cached_results;
+        const cCols = [
+          ["cached_tokens", "cached tokens", {}],
+          ["delta_tokens", "new tokens", {}],
+          ["incremental_prompt_tps", "incr. prompt t/s", {}],
+          ["generation_tps", "gen t/s", {}],
+          ["time_to_first_token", "ttft", { seconds: true }],
+          ["kv_cache_gb", "kv cache GB", {}],
+        ].filter(([key]) => cachedRows.some(r => r[key] != null));
+        return `
+        <h3 style="font-size:14px;margin:18px 0 4px">Cached re-prompt <span class="unit">KV-cache reuse</span></h3>
+        <p class="hint" style="margin:0 0 8px">Warm runs on top of a stored KV cache — »incr. prompt«
+          only counts the tokens added after the cached prefix.</p>
+        <div class="tbl-wrap"><table class="tbl">
+          <thead><tr><th>context</th>${cCols.map(([, label]) => `<th>${esc(label)}</th>`).join("")}</tr></thead>
+          <tbody>${cachedRows.map(r => `<tr><td>${esc(r.context_size)}</td>
+            ${cCols.map(([key, , o]) => `<td>${esc(fmt(r[key], o))}</td>`).join("")}
+          </tr>`).join("")}</tbody>
+        </table></div>`;
+      })() : ""}
       ${detail.batch_data && detail.batch_data.length ? (() => {
-        const hasDecode = detail.batch_data.some(b => b.decode_tps_total != null);
+        const batchRows = detail.batch_data;
+        const bCols = [
+          ["prompt_tps", "prompt t/s", {}],
+          ["generation_tps", "e2e gen t/s", {}],
+          ["decode_tps_total", "decode t/s", {}],
+          ["decode_tps_per_client", "decode / client", {}],
+          ["time_to_first_token", "ttft", { seconds: true }],
+          ["time_per_output_token", "tpot", { seconds: true }],
+          ["peak_memory_gb", "peak GB", {}],
+          ["kv_cache_gb", "kv GB", {}],
+          ["host_memory_gb", "host GB", {}],
+        ].filter(([key]) => batchRows.some(b => b[key] != null && b[key] > 0));
+        const hasDecode = bCols.some(([key]) => key === "decode_tps_total");
         return `
         <h3 style="font-size:14px;margin:18px 0 4px">Batch sweep <span class="unit">N parallel clients</span></h3>
         <p class="hint" style="margin:0 0 8px">»E2E gen« = generated tokens ÷ total wall time (prompt
           phase included)${hasDecode ? " — »decode« = pure generation rate, summed across clients" : ""}.</p>
         <div class="tbl-wrap"><table class="tbl">
-          <thead><tr><th>batch</th><th>prompt t/s</th><th>e2e gen t/s</th>
-            ${hasDecode ? "<th>decode t/s</th><th>decode / client</th>" : ""}</tr></thead>
-          <tbody>${detail.batch_data.map(b => `<tr><td>${esc(b.batch_size)}</td>
-            <td>${esc(fmt(b.prompt_tps))}</td><td>${esc(fmt(b.generation_tps))}</td>
-            ${hasDecode ? `<td>${esc(fmt(b.decode_tps_total))}</td><td>${esc(fmt(b.decode_tps_per_client))}</td>` : ""}
+          <thead><tr><th>batch</th>${bCols.map(([, label]) => `<th>${esc(label)}</th>`).join("")}</tr></thead>
+          <tbody>${batchRows.map(b => `<tr><td>${esc(b.batch_size)}</td>
+            ${bCols.map(([key, , o]) => `<td>${esc(fmt(b[key], o))}</td>`).join("")}
           </tr>`).join("")}</tbody>
         </table></div>`;
       })() : ""}
@@ -190,13 +221,15 @@
     for (const key of chartKeys) {
       const node = modal.querySelector(`[data-chart="${key}"]`);
       const metric = METRICS.find(m => m.key === key) || {};
+      const series = [{
+        name: seriesLabel(summary), color,
+        points: rows.map(r => [ctxNum(r.context_size), r[key]]),
+      }];
+      const cached = cachedSeriesPoints(detail, key);
+      if (cached) series.push({ name: "cached (incremental)", color, dash: true, points: cached });
       Charts.lineChart(node, {
-        series: [{
-          name: seriesLabel(summary), color,
-          points: rows.map(r => [ctxNum(r.context_size), r[key]]),
-        }],
-        logX: true, height: 190, seconds: metric.seconds,
-        xLabel: "context", yLabel: metric.unit || "", legend: false,
+        series, logX: true, height: 190, seconds: metric.seconds,
+        xLabel: "context", yLabel: metric.unit || "", legend: !!cached,
       });
     }
   }


### PR DESCRIPTION
Two quality-of-life features for the web UI, plus a small cleanup pass.

## 1. Auto-append `/v1` to path-less base URLs (`5bef548`)

A base URL saved without the `/v1` suffix (e.g. `http://host:8000` instead of `http://host:8000/v1`) made every run against an OpenAI-compatible server fail immediately with a 404 on the connection test — an easy mistake to make and a confusing one to debug from the run log.

The web UI now fixes this automatically instead of failing:

- **Probed, never guessed**: when an endpoint is saved with a URL that has no path, the server probes `GET /models` vs `GET /v1/models` and appends `/v1` only if the server actually answers there. If the server is unreachable, the URL is left exactly as entered.
- **Engine-aware**: the correction only applies to engines whose script takes the base URL verbatim as an OpenAI-style `/v1` root — derived from the engine's `default_base_url` ending in `/v1` (openai, vllm, omlx, vmlx, unsloth, deepseek, grok). Engines that want the bare root (lmstudio, exo) or normalize the URL themselves (mtplx, dflash) are never touched, and URLs that already carry any path are trusted as-is.
- **Applied twice**: on endpoint create/update (the UI toasts the corrected URL so nothing happens silently), and again at run start as a safety net for endpoints that were saved while their server was offline — the corrected URL goes into the benchmark command and self-heals the stored endpoint.

## 2. Chart picker for ZIP / HTML / PDF exports (`c84b9e7`)

Clicking an export button now opens a small popover listing every chart the selected runs can produce — the context-sweep metrics (generation/prompt tok/s, TTFT, TPOT, total time, bytes/s, memory panels) plus the batch-sweep charts — so you can choose exactly which ones end up in the export.

- Checkboxes with **All** / **None** shortcuts; a second click on the same export button toggles the picker away.
- The deselection is remembered across exports (stored as an off-list in `localStorage`, so metrics that appear in later runs default to on).
- Only the **charts** are filtered — CSVs, value tables and the plain-text summary always contain the complete data.
- With zero charts selected, the ZIP simply skips the overview PNG and ships data only.
- Works in both places that export: the Compare view and the result detail dialog.

## 3. Cleanup (`087f359`)

Removed a dead `CB.report.metricsForEntries` export, unified the duplicated chart filtering (sweep and batch charts now filter through the same `only` set), and inlined a single-use helper in `webui.py`. No behavior change.

## 4. CLI chart parity + relative comparison (`04c18a1`)

Closes the remaining gaps between the web UI and the matplotlib charts the CLI scripts produce, and adds two analysis tools on top:

- **Cached KV-reuse overlays** — MLX `--cached` runs store warm re-prompt measurements in `all_results_cached.json`; the API already delivered them, but no view rendered them. They now appear as dashed »cached (incremental)« overlays on the prompt-TPS, generation-TPS and TTFT charts (detail dialog, Compare, and all exports), plus a cached re-prompt table in the detail dialog and a `cached_results.csv` in ZIP exports.
- **Full batch-sweep panels** — TTFT, TPOT, peak memory and KV cache per batch size now chart alongside the throughput panels (matching the CLI's batch rows), and the detail batch table shows every recorded column. Zero values are treated as »not recorded«, like the CLI does.
- **Chars/s metrics** — `generation_chars_per_sec` / `prompt_chars_per_sec` join the metric list (tabs, grid, tables, export picker).
- **Baseline mode in Compare** — a »Relative to ‹run›« picker re-plots every series as a percentage of the chosen run at the same context size, so hardware comparisons read directly as speedups (baseline stays flat at 100 %).
- **Context-degradation row** — the Compare values table ends with »‹max›k / ‹min›k«: the value at the largest context as a percentage of the smallest, i.e. how much throughput a setup retains under long context.

Verified headless (Playwright) against a synthetic MLX result carrying cached + batch data: 3 dashed overlays in the detail dialog, 8 batch panels, baseline table shows the baseline flat at 100, and the HTML export contains all 18 figures with the dashed cached series intact.

## 5. Metric explanations + export completeness (`8eeb455`)

Every metric and batch chart now carries a one-sentence description of what it measures and which direction is better:

- Chart titles (Compare hero/grid/batch panels, detail dialog) get a hoverable, keyboard-focusable »?« marker; the metric tabs and the export picker expose the text as native tooltips.
- The exported HTML report renders the same »?« on figures and table headings (pure-CSS tooltip, still fully self-contained); the PDF prints the description as a grey subtitle under each chart and table; the ZIP's `comparison.txt` carries it under each table heading.
- Export completeness pass: TXT/HTML/PDF tables now cover everything the charts show — three cached re-prompt tables and one table per batch chart replace the old combined three-column batch table.
- Fix: the »Relative to« baseline picker was visible with fewer than two runs selected (`hidden` attribute lost against `.check`'s `display:flex`).

## 6. Exports no longer claim the local machine ran the benchmark (`bf1aa35`)

The runs metadata in exports showed the locally detected chip (e.g. »Apple M4 Pro«) — misleading whenever the inference actually ran on a remote endpoint. Exports now show the **endpoint name** instead (the machine that served the run): HTML runs table, PDF cover, `comparison.txt`, ZIP overview subtitle and the `results.csv` meta column.

## 7. Value labels on static export charts (`77cb08e`)

The ZIP overview PNG and the PDF charts have no hover tooltip, so every data point now carries its value in the series color. Labels that share an x position are de-overlapped vertically (keeping the dots' top-to-bottom order), clamped to the plot area, and drawn with a surface-colored halo (`paint-order: stroke`) so they stay readable where lines cross. The interactive HTML report keeps its hover tooltips instead. Also removed the redundant »context (tokens ×1000)« x-axis label from export charts — the `0.5k / 1k / …` ticks already say it.

## 8. Follow-up cleanup (`823573b`)

Dead/duplicate-code pass over the later features: the batch and cached CSV builders collapse into one shared helper, the cached/batch table definitions live in `report.js` next to the chart definitions (with an explicit `unit` field instead of three regexes re-extracting »[tok/s]« from titles), and two summary flags the frontend never consumed are gone from `webui.py`. No behavior change.

## Testing

- Verified headless (Playwright + Chromium) against real benchmark results: an HTML export with 2 of 9 charts selected contains exactly 2 figures; picker toggle, outside-click close and preference persistence behave; popover placement is clean both in Compare and inside the detail modal.
- `/v1` normalization verified against a live OpenAI-compatible server and a mock that only answers under `/v1`: path-less URLs get corrected on save (`base_url_corrected` toast) and at run start; URLs with `/v1`, lmstudio-style root URLs and unreachable servers stay untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
