### PR TITLE
Docker support: containerized web UI for benchmarking remote endpoints

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# VCS / editor / local tooling
+.git
+.claude
+.vscode
+.idea
+.DS_Store
+
+# Python build artifacts and the host virtualenv
+.venv
+__pycache__
+*.pyc
+*.egg-info
+build/
+dist/
+
+# Local state — mounted as volumes, never baked into the image
+output/
+comparison_results/
+old/
+*.log
+
+# Endpoint store contains API keys — must never end up in an image layer
+webui_endpoints.json
+
+# Docker files themselves
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy
+    UV_LINK_MODE=copy \
+    # tells the web UI to show container-specific hints (host.docker.internal)
+    CONTEXT_BENCH_CONTAINER=1
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Web UI + CLI benchmarks against remote/OpenAI-compatible endpoints.
+# MLX-local engines require Apple Silicon and are disabled inside the
+# container automatically (webui_common.is_apple_silicon()).
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_SYSTEM_PYTHON=1 \
+    UV_LINK_MODE=copy
+
+WORKDIR /app
+
+# Dependency layer — deliberately NOT pyproject.toml: the container only
+# talks to inference servers over HTTP, so the heavy local-inference stack
+# (mlx, torch, transformers, datasets) stays out of the image.
+COPY requirements-docker.txt ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -r requirements-docker.txt
+
+# Application code (flat modules + webui_static + sample context files)
+COPY . .
+
+EXPOSE 8321
+
+# Run the module directly: /app comes first on sys.path, so a bind mount of
+# the project overrides the baked-in copy without reinstalling anything.
+CMD ["python", "webui.py", "--host", "0.0.0.0", "--port", "8321", "--no-open"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,36 @@ uv run benchmark-webui --host 0.0.0.0 --port 9000 --no-open
 - **Compare** — select up to 8 runs and compare any metric (generation/prompt
   t/s, TTFT, TPOT, memory, KV cache, batch sweeps) in interactive charts.
 
+### Docker
+
+The web UI can also run in a container — no local Python or `uv` needed:
+
+```bash
+docker compose up -d              # build + start, UI on http://127.0.0.1:8321
+docker compose logs -f webui      # follow server + benchmark logs
+docker compose down               # stop
+docker compose up -d --build      # rebuild after pulling code changes
+```
+
+The container is a pure benchmark *client* (~400 MB): it only ships the web UI
+and the HTTP client libraries, so it benchmarks remote endpoints you add in
+the UI (Ollama, llama.cpp, LM Studio, vLLM, MLX-Serve, any OpenAI-compatible
+server). Nothing runs models inside the container — mlx/torch/transformers are
+deliberately not installed (`requirements-docker.txt`), and the local-MLX
+engines are disabled in the engine picker.
+
+Notes:
+
+- The project directory is bind-mounted, so results (`output/`), generated
+  context files, and saved endpoints (`webui_endpoints.json`) live on the host
+  and survive rebuilds.
+- To benchmark a server running on the Docker host itself, use
+  `http://host.docker.internal:<port>` as the endpoint URL instead of
+  `localhost`.
+- The port is bound to `127.0.0.1` on purpose (the UI has no auth and the
+  endpoint store holds API keys). Edit `docker-compose.yml` to expose it on
+  the LAN.
+
 ## Running Benchmarks
 
 ```bash
@@ -183,6 +213,7 @@ llm_context_benchmarks/
 - Python 3.13+
 - `uv` for dependency management
 - Engine-specific runtime (see Installation table)
+- Or just Docker, for the web UI against remote endpoints (see [Docker](#docker))
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       # so the whole project is mounted: results and endpoints are shared
       # with the host and survive rebuilds. Dependencies live in the image.
       - .:/app
+    environment:
+      # result folders are timestamped with local time, not UTC
+      TZ: Europe/Berlin
     extra_hosts:
       # Reach servers running on the host (Ollama, llama.cpp, LM Studio, …)
       # via http://host.docker.internal:<port> in endpoint URLs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  webui:
+    build: .
+    container_name: llm-context-bench
+    # Reaps finished benchmark subprocesses (they run as children of the server)
+    init: true
+    # Bound to loopback on purpose: the UI has no auth and the endpoint store
+    # holds API keys. Change to "8321:8321" to expose it on the LAN.
+    ports:
+      - "127.0.0.1:8321:8321"
+    volumes:
+      # The app keeps all mutable state flat in the project root (results in
+      # output/, generated {size}k.txt context files, webui_endpoints.json),
+      # so the whole project is mounted: results and endpoints are shared
+      # with the host and survive rebuilds. Dependencies live in the image.
+      - .:/app
+    extra_hosts:
+      # Reach servers running on the host (Ollama, llama.cpp, LM Studio, …)
+      # via http://host.docker.internal:<port> in endpoint URLs.
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8321/api/meta', timeout=5)"]
+      interval: 30s
+      timeout: 10s
+      start_period: 10s

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,0 +1,16 @@
+# Minimal dependency set for the Docker image: web UI + the HTTP/API-based
+# engines (ollama-api, llamacpp, lmstudio, exo, deepseek, grok, openai,
+# unsloth, vllm, mlx-serve, mtplx, omlx, ...). Local-MLX engines are
+# Apple-Silicon-only and disabled inside the container, so mlx*, torch*,
+# transformers, datasets etc. are deliberately absent.
+fastapi>=0.115.0
+uvicorn>=0.30.0
+httpx>=0.28.1
+requests>=2.33.1
+openai>=2.33.0
+ollama>=0.6.2
+numpy>=2.4.4
+pandas>=3.0.2
+matplotlib>=3.10.9
+psutil>=7.2.2
+tiktoken>=0.12.0

--- a/webui.py
+++ b/webui.py
@@ -186,6 +186,15 @@ def resolve_result_folder(name: str) -> Path:
 app = FastAPI(title="LLM Context Bench", docs_url=None, redoc_url=None)
 
 
+def in_container() -> bool:
+    """True when the server runs inside a container (Docker/Podman)."""
+    return (
+        os.environ.get("CONTEXT_BENCH_CONTAINER") == "1"
+        or Path("/.dockerenv").exists()
+        or Path("/run/.containerenv").exists()
+    )
+
+
 @app.get("/api/meta")
 def api_meta():
     catalog = get_engine_catalog()
@@ -217,6 +226,7 @@ def api_meta():
     hw = benchmark_common.get_hardware_info()
     return {
         "engines": engines,
+        "in_container": in_container(),
         "mlx_available": is_apple_silicon(),
         "hardware": hw,
         "hardware_string": benchmark_common.format_hardware_string(hw),

--- a/webui.py
+++ b/webui.py
@@ -529,6 +529,16 @@ app.mount("/output", StaticFiles(directory=str(OUTPUT_DIR), check_dir=False), na
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 
+@app.middleware("http")
+async def revalidate_app_assets(request: Request, call_next):
+    """App JS/CSS changes with every update; no-cache makes browsers revalidate
+    instead of heuristically reusing stale files (ETag 304s keep it cheap)."""
+    response = await call_next(request)
+    if request.url.path == "/" or request.url.path.startswith("/static"):
+        response.headers["Cache-Control"] = "no-cache"
+    return response
+
+
 @app.get("/")
 def index():
     return FileResponse(STATIC_DIR / "index.html")

--- a/webui.py
+++ b/webui.py
@@ -323,7 +323,10 @@ def api_endpoints_ping(endpoint_id: str):
     endpoint = next((e for e in load_endpoints() if e["id"] == endpoint_id), None)
     if endpoint is None:
         raise HTTPException(404, "Endpoint not found")
-    url = (endpoint.get("base_url") or "").strip()
+    url = (endpoint.get("base_url") or "").strip().rstrip("/")
+    if url.endswith("/v1"):
+        # OpenAI-style servers don't serve the bare /v1 root; probe the real route
+        url += "/models"
     if not url and endpoint.get("host"):
         url = f"http://{endpoint['host']}:{endpoint.get('port') or 8080}/health"
     if not url:

--- a/webui_static/styles.css
+++ b/webui_static/styles.css
@@ -221,6 +221,7 @@ button:focus-visible, a:focus-visible, [tabindex]:focus-visible,
   outline-offset: 1px;
 }
 .field .hint { font-size: 11px; color: var(--muted); }
+.field .hint.warn { color: var(--warning); }
 .field input::placeholder, .field textarea::placeholder { color: color-mix(in srgb, var(--muted) 75%, transparent); }
 .form-row { display: grid; gap: 12px; margin-bottom: 12px; }
 .form-row.cols-2 { grid-template-columns: 1fr 1fr; }

--- a/webui_static/view-endpoints.js
+++ b/webui_static/view-endpoints.js
@@ -137,11 +137,13 @@
           </select>
           <span class="hint" id="epEngineHint"></span></div>
         <div class="field" id="epBaseUrlField"><label for="epBaseUrl">Base URL</label>
-          <input type="text" id="epBaseUrl" value="${esc(ep.base_url || "")}" placeholder="http://192.168.1.20:8000/v1"></div>
+          <input type="text" id="epBaseUrl" value="${esc(ep.base_url || "")}" placeholder="http://192.168.1.20:8000/v1">
+          <span class="hint" id="epBaseUrlHint"></span></div>
       </div>
       <div class="form-row cols-2" id="epHostRow">
         <div class="field"><label for="epHost">Host</label>
-          <input type="text" id="epHost" value="${esc(ep.host || "")}" placeholder="192.168.1.20"></div>
+          <input type="text" id="epHost" value="${esc(ep.host || "")}" placeholder="192.168.1.20">
+          <span class="hint" id="epHostHint"></span></div>
         <div class="field"><label for="epPort">Port</label>
           <input type="number" id="epPort" value="${esc(ep.port || "")}" placeholder="8080"></div>
       </div>
@@ -177,6 +179,27 @@
     };
     modal.querySelector("#epEngine").addEventListener("change", syncConnectionFields);
     syncConnectionFields();
+
+    // Inside Docker, "localhost" is the container itself — servers on the
+    // machine running Docker are reachable via host.docker.internal instead.
+    if (state.meta.in_container) {
+      const LOOPBACK_RE = /localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?/i;
+      const dockerHint = (input, hint) => {
+        const sync = () => {
+          if (LOOPBACK_RE.test(input.value)) {
+            hint.textContent = "This points at the container itself, not this machine — use host.docker.internal instead.";
+            hint.classList.add("warn");
+          } else {
+            hint.textContent = "Running in Docker: for a server on this machine use host.docker.internal, not localhost.";
+            hint.classList.remove("warn");
+          }
+        };
+        input.addEventListener("input", sync);
+        sync();
+      };
+      dockerHint(modal.querySelector("#epBaseUrl"), modal.querySelector("#epBaseUrlHint"));
+      dockerHint(modal.querySelector("#epHost"), modal.querySelector("#epHostHint"));
+    }
 
     const epConnection = () => {
       const engineId = modal.querySelector("#epEngine").value;


### PR DESCRIPTION
Run the web UI in a container — as a pure benchmark **client** against remote inference endpoints. `docker compose up -d`, add your endpoints in the UI, benchmark.

## What's included

### Docker setup
- **`Dockerfile`** — `uv` base image with Python 3.13. Installs from a dedicated **`requirements-docker.txt`** (11 packages) instead of `pyproject.toml`: the container only talks to inference servers over HTTP, so the local-inference stack (mlx/torch/transformers/datasets) stays out. Result: a **~400 MB** image instead of ~7 GB (the full dependency set resolves to CUDA torch on Linux). Local-MLX engines are disabled in the engine picker automatically, everything HTTP-based (Ollama, llama.cpp, LM Studio, vLLM, Exo, MLX-Serve, any OpenAI-compatible server) works.
- **`docker-compose.yml`** — bind-mounts the project so results (`output/`), generated context files, and the endpoint store live on the host and survive rebuilds. Port bound to `127.0.0.1` by default (the UI has no auth and the endpoint store holds API keys), `host.docker.internal` wired up for servers running on the Docker host, healthcheck, `TZ` set so result folders are stamped in local time instead of UTC.
- **`.dockerignore`** — keeps `output/` and especially `webui_endpoints.json` (API keys) out of image layers.
- README section with usage.

### Web UI fixes that surfaced during container testing
- **Endpoint ping no longer 404-spams server logs**: the reachability ping used to `GET` the bare base URL — for OpenAI-style URLs that's `GET /v1`, which vLLM answers with 404 on every ping. It now probes the real `/v1/models` route.
- **`host.docker.internal` guidance in the endpoint form**: when the server runs inside a container (auto-detected via env marker / `/.dockerenv` / Podman marker, exposed as `in_container` in `/api/meta`), the Base URL and Host fields explain that servers on the Docker host are reached via `host.docker.internal` — and warn live (in yellow) when a loopback address is typed, since `localhost` would point at the container itself. Outside a container nothing changes.

## Verification
- Image builds clean; container runs healthy; all 21 engines listed with the 4 local-MLX ones correctly disabled on Linux/aarch64; `mlx`/`torch`/`transformers`/`datasets` confirmed absent from the image.
- Existing results and endpoints from the host are visible through the bind mount; a real vLLM benchmark ran end-to-end from inside the container.
- Endpoint-form hints verified with headless-browser tests (hint shown, warning triggers on `localhost`/`127.0.0.1`/`::1`, clears on `host.docker.internal`); ping fix verified against a live vLLM server log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
