### PR TITLE
feat(webui): delete finished runs from the live run list

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -485,6 +485,12 @@ def api_runs_stop(run_id: str):
     return run_manager.stop(run_id).snapshot()
 
 
+@app.delete("/api/runs/{run_id}")
+def api_runs_delete(run_id: str):
+    run_manager.delete(run_id)
+    return {"ok": True}
+
+
 @app.get("/api/results")
 def api_results_list():
     if not OUTPUT_DIR.is_dir():

--- a/webui_runs.py
+++ b/webui_runs.py
@@ -181,6 +181,15 @@ class RunManager:
             threading.Timer(10, lambda: proc.poll() is None and proc.kill()).start()
         return run
 
+    def delete(self, run_id):
+        run = self.get(run_id)
+        # stop an in-flight run first so its subprocess doesn't outlive the card
+        if run.status in ("starting", "running"):
+            self.stop(run_id)
+        with self.lock:
+            self.runs.pop(run_id, None)
+        return run
+
     def _execute(self, run: BenchmarkRun):
         OUTPUT_DIR.mkdir(exist_ok=True)
         before = {p.name for p in OUTPUT_DIR.iterdir() if p.is_dir()}

--- a/webui_static/view-run.js
+++ b/webui_static/view-run.js
@@ -340,6 +340,7 @@
         <div class="run-card-spacer"></div>
         <button class="btn small" data-act="toggle-log">Log</button>
         <button class="btn small danger" data-act="stop">Stop</button>
+        <button class="btn small danger" data-act="delete" hidden>Delete</button>
       </div>
       <div class="readout">
         <div class="readout-cell"><span class="eyebrow" data-f="prompt-label">Prompt</span>
@@ -357,6 +358,13 @@
     card.querySelector('[data-act="stop"]').addEventListener("click", async () => {
       try { await api(`/api/runs/${run.id}/stop`, { method: "POST" }); } catch (e) { toast(e.message, true); }
     });
+    card.querySelector('[data-act="delete"]').addEventListener("click", async () => {
+      if (!confirm("Remove this run from the list?")) return;
+      try {
+        await api(`/api/runs/${run.id}`, { method: "DELETE" });
+        card.remove();
+      } catch (e) { toast(e.message, true); }
+    });
     card.querySelector('[data-act="toggle-log"]').addEventListener("click", () => {
       const log = card.querySelector('[data-f="log"]');
       log.hidden = !log.hidden;
@@ -370,6 +378,9 @@
   async function updateRunCard(card, run) {
     const dot = card.querySelector(".led");
     dot.className = "led " + run.status;
+    const active = run.status === "running" || run.status === "starting";
+    card.querySelector('[data-act="stop"]').hidden = !active;
+    card.querySelector('[data-act="delete"]').hidden = active;
     card.querySelector(".run-card-title").textContent =
       (run.label ? run.label + " — " : "") + run.engine + " · " + run.model;
     const statusText = { starting: "starting", running: "running", done: "completed",


### PR DESCRIPTION
Failed and stale runs lingered in the **LIVE · Active & recent runs** list until the server restarted.

## Changes
- `DELETE /api/runs/{id}` — removes a run from the in-memory `RunManager` (stops it first if still active). Saved result folders on disk are untouched; those stay under the Results view.
- `RunManager.delete()` backend method.
- A **Delete** button on each run card that swaps in for **Stop** once a run is `done` / `failed` / `stopped` — surfacing Delete exactly on the runs that need clearing.

## Notes
- `webui_runs.py`, `webui.py`, `webui_static/view-run.js` — 3 files, +26 lines.
- Python + JS parse clean; no automated tests in this project.