### PR TITLE
feat(webui): add GitHub repo link to the side rail

### DIFF
--- a/webui_static/index.html
+++ b/webui_static/index.html
@@ -38,6 +38,10 @@
       <div class="hw-readout" id="hwReadout" title="">–</div>
       <div class="mlx-badge" id="mlxBadge"></div>
       <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle color theme">◐ theme</button>
+      <a class="rail-link" href="https://github.com/ivanfioravanti/llm_context_benchmarks" target="_blank" rel="noopener noreferrer" title="GitHub repository">
+        <svg class="rail-link-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+        GitHub
+      </a>
     </div>
   </aside>
   <main class="main" id="main">

--- a/webui_static/styles.css
+++ b/webui_static/styles.css
@@ -155,6 +155,15 @@ input, select, textarea { font: inherit; }
   padding: 4px 9px; cursor: pointer; letter-spacing: 0.07em;
 }
 .theme-toggle:hover { color: var(--ink); border-color: var(--border); }
+.rail-link {
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--sunken); border: 1px solid var(--hairline); border-radius: 6px;
+  color: var(--muted); font-family: var(--mono); font-size: 10px;
+  padding: 4px 9px; text-decoration: none; letter-spacing: 0.07em;
+}
+.rail-link:hover { color: var(--ink); border-color: var(--border); }
+.rail-link-icon { width: 13px; height: 13px; }
 
 .main { flex: 1; min-width: 0; padding: 30px 38px 70px; }
 


### PR DESCRIPTION
Adds a GitHub mark chip to the left rail `.rail-foot`, styled as a sibling of the theme toggle, linking to the repository in a new tab (`target="_blank" rel="noopener noreferrer"`).

- `webui_static/index.html` — `.rail-link` anchor with inline Octicon mark.
- `webui_static/styles.css` — `.rail-link` chip mirroring `.theme-toggle`.

Picked up on reload via the existing `no-cache` asset middleware.