### PR TITLE
Fix Ollama cold-prefill cache isolation

### DIFF
--- a/benchmark_common.py
+++ b/benchmark_common.py
@@ -1721,7 +1721,14 @@ def _is_degenerate_generation(result: Dict) -> bool:
     return False
 
 
-def run_benchmark_peak(run_fn, *args, n_runs=2, metric="generation_tps", **kwargs):
+def run_benchmark_peak(
+    run_fn,
+    *args,
+    n_runs=2,
+    metric="generation_tps",
+    reject_prefill_cache_hits=False,
+    **kwargs,
+):
     """Run benchmark N times and return the result with peak generation_tps.
 
     Each run gets a unique ``_run_idx`` keyword argument so the engine can
@@ -1738,13 +1745,14 @@ def run_benchmark_peak(run_fn, *args, n_runs=2, metric="generation_tps", **kwarg
         *args: Positional arguments forwarded to run_fn.
         n_runs: Number of runs per context size.
         metric: Metric to maximize when selecting the peak run.
+        reject_prefill_cache_hits: Discard trials whose prompt-evaluation time
+            is over 10x faster than a comparable trial with the same token count.
         **kwargs: Keyword arguments forwarded to run_fn.
 
     Returns:
         Result dict from the run with the highest metric value, or None if all runs fail.
     """
-    best_result = None
-    best_score = -1
+    run_results = []
     for run_idx in range(1, n_runs + 1):
         print(f"  Run {run_idx}/{n_runs}...")
         kwargs["_run_idx"] = run_idx
@@ -1759,9 +1767,37 @@ def run_benchmark_peak(run_fn, *args, n_runs=2, metric="generation_tps", **kwarg
                 continue
             score = result.get(metric, 0)
             print(f"    {metric}: {score:.2f}")
-            if score > best_score:
-                best_score = score
-                best_result = result
+            run_results.append(result)
+
+    # A cached prompt can have nearly the same reported token count but orders
+    # of magnitude less prompt-evaluation time. If requested by an engine that
+    # promises cold prefill, discard those trials before choosing by the normal
+    # peak metric. This is a safety net; engines should still clear their cache
+    # explicitly before every run.
+    if reject_prefill_cache_hits and len(run_results) > 1:
+        reference = max(run_results, key=lambda r: r.get("prompt_eval_duration", 0))
+        reference_duration = reference.get("prompt_eval_duration", 0)
+        reference_tokens = reference.get("prompt_tokens", 0)
+        filtered_results = []
+        for result in run_results:
+            duration = result.get("prompt_eval_duration", 0)
+            tokens = result.get("prompt_tokens", 0)
+            token_delta = abs(tokens - reference_tokens) / max(tokens, reference_tokens, 1)
+            looks_cached = (
+                reference_duration > 0 and duration > 0 and duration * 10 < reference_duration and token_delta < 0.05
+            )
+            if looks_cached:
+                print(
+                    f"    Rejecting likely prompt-cache hit: {tokens} tokens in {duration:.6f}s "
+                    f"vs cold reference {reference_duration:.6f}s"
+                )
+            else:
+                filtered_results.append(result)
+        if filtered_results:
+            run_results = filtered_results
+
+    best_result = max(run_results, key=lambda r: r.get(metric, 0), default=None)
+    best_score = best_result.get(metric, 0) if best_result else -1
     if best_result:
         print(f"  Peak {metric}: {best_score:.2f}")
     # Clean up so the kwarg doesn't leak if the dict is reused

--- a/ollama_api_benchmark.py
+++ b/ollama_api_benchmark.py
@@ -34,7 +34,7 @@ def _derive_num_ctx(context_file: Path, max_tokens: int) -> tuple[int, int]:
 
 
 def _make_cache_buster(run_idx: Optional[int] = None) -> str:
-    """Generate a prefix to bust Ollama's prompt cache.
+    """Generate a prefix to isolate intentional cache-reuse runs.
 
     Ollama/llama.cpp automatically reuses the KV cache whenever a new prompt
     shares a prefix with the previous request in the same slot.
@@ -43,13 +43,19 @@ def _make_cache_buster(run_idx: Optional[int] = None) -> str:
     all calls within the same run share the same prefix (so KV cache carries
     over across context sizes), while different runs get different prefixes
     (so runs don't interfere). When ``run_idx`` is None, a random UUID is
-    used for full cold-prefill busting. ~10 tokens of overhead per prompt.
+    used to distinguish concurrent batch requests. The main cold-prefill sweep
+    unloads the runner instead because a prefix alone is not reliable.
     """
     if run_idx is not None:
         return f"[run-{run_idx}]\n"
     import uuid
 
     return f"[session-{uuid.uuid4().hex[:16]}]\n"
+
+
+def _unload_model(model_name: str) -> None:
+    """Synchronously unload an Ollama runner and discard its prompt cache."""
+    ollama.generate(model=model_name, prompt="", keep_alive=0)
 
 
 def run_benchmark(
@@ -75,19 +81,29 @@ def run_benchmark(
     with open(context_file) as f:
         prompt = f.read()
 
-    # Bust Ollama's prompt cache by prepending a unique marker. Without this,
-    # the KV cache from a previous warmup or benchmark row that shares a
-    # prefix will be reused, inflating prompt_tps (prompt_eval_count covers
-    # the full prompt but prompt_eval_duration covers only the uncached delta).
-    if cold_prefill:
-        prompt = _make_cache_buster() + prompt
-    elif _run_idx is not None:
+    # A prefix marker is sufficient for the intentional cache-reuse mode, where
+    # it isolates one run from another while preserving reuse across context
+    # sizes inside a run. It is not a reliable way to force cold prefill in
+    # Ollama, especially for long nested prompts; cold mode unloads the runner
+    # below instead.
+    if not cold_prefill and _run_idx is not None:
         prompt = _make_cache_buster(run_idx=_run_idx) + prompt
 
     # Size the KV cache to fit this context file (plus generation headroom).
     # Without this, Ollama silently caps num_ctx at its default (2048), which
     # turns every large-context row into a measurement of ~2k prefill.
     num_ctx, expected_prompt_tokens = _derive_num_ctx(context_file, max_tokens)
+
+    # Ollama owns the KV cache in its persistent daemon, so a new Python call
+    # does not imply a fresh prompt state. Explicitly unload before every cold
+    # trial. keep_alive=0 on the measured request also leaves the next trial
+    # cold even if this process is interrupted between rows.
+    if cold_prefill:
+        try:
+            _unload_model(model_name)
+        except Exception as e:
+            print(f"Error clearing Ollama prompt cache before cold prefill: {e}")
+            return None
 
     # Start timing
     start_time = time.time()
@@ -101,7 +117,7 @@ def run_benchmark(
                 "num_predict": max_tokens,
                 "num_ctx": num_ctx,
             },
-            keep_alive="10m",
+            keep_alive=0 if cold_prefill else "10m",
         )
 
         # Calculate total time
@@ -391,8 +407,8 @@ def main() -> int:
         "--cold-prefill",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Prepend a unique marker to every prompt to bust Ollama's KV "
-        "cache reuse, forcing cold prefill on every row (default: enabled; "
+        help="Unload the Ollama runner before every prompt to discard its KV "
+        "cache, forcing cold prefill on every row (default: enabled; "
         "use --no-cold-prefill for cached/warm-reuse numbers)",
     )
 
@@ -451,7 +467,7 @@ def main() -> int:
     print(f"Model: {args.model}")
     print(f"Max tokens: {args.max_tokens}")
     print(
-        f"Cold prefill: {'enabled (cache busted per prompt)' if args.cold_prefill else 'disabled (cache reuse allowed)'}"
+        f"Cold prefill: {'enabled (runner reset per prompt)' if args.cold_prefill else 'disabled (cache reuse allowed)'}"
     )
 
     # Warmup run — max_tokens=1 is enough to load weights and hit the code
@@ -476,7 +492,13 @@ def main() -> int:
             print(f"{'=' * 50}")
 
             result = common.run_benchmark_peak(
-                run_benchmark, args.model, file, args.max_tokens, cold_prefill=args.cold_prefill, n_runs=args.runs
+                run_benchmark,
+                args.model,
+                file,
+                args.max_tokens,
+                cold_prefill=args.cold_prefill,
+                n_runs=args.runs,
+                reject_prefill_cache_hits=True,
             )
             if result:
                 results.append(result)

--- a/ollama_cli_benchmark.py
+++ b/ollama_cli_benchmark.py
@@ -81,8 +81,25 @@ def _remove_temp_model(tag: str) -> None:
         pass
 
 
+def _stop_model(tag: str) -> None:
+    """Stop a daemon-side runner so its KV prompt cache cannot be reused."""
+    result = subprocess.run(
+        ["ollama", "stop", tag],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    # `ollama stop` may report that an already-unloaded model was not found;
+    # that is already the desired state. Other daemon failures will surface
+    # again when the measured `ollama run` command is attempted.
+    stderr = result.stderr.lower()
+    already_stopped = "not found" in stderr or "couldn't find model" in stderr
+    if result.returncode != 0 and not already_stopped:
+        raise RuntimeError(f"ollama stop failed for '{tag}': {result.stderr.strip()}")
+
+
 def _make_cache_buster(run_idx: Optional[int] = None) -> str:
-    """Generate a prefix to bust Ollama's prompt cache.
+    """Generate a prefix to isolate intentional cache-reuse runs.
 
     Ollama reuses KV cache whenever a new prompt shares a prefix with the
     previous request.
@@ -91,7 +108,8 @@ def _make_cache_buster(run_idx: Optional[int] = None) -> str:
     all calls within the same run share the same prefix (so KV cache carries
     over across context sizes), while different runs get different prefixes
     (so runs don't interfere). When ``run_idx`` is None, a random UUID is
-    used for full cold-prefill busting. ~10 tokens of overhead per prompt.
+    used to distinguish concurrent batch requests. The main cold-prefill sweep
+    stops the runner instead because a prefix alone is not reliable.
     """
     if run_idx is not None:
         return f"[run-{run_idx}]\n"
@@ -226,8 +244,8 @@ def run_cli_benchmark(
         model_name: Name of the Ollama model (expected to be a temp model with
             num_ctx and num_predict parameters baked in via Modelfile)
         context_file: Path to the context file
-        cold_prefill: If True, prepend a unique cache-buster to the prompt so
-            Ollama's KV cache reuse doesn't inflate prompt-processing numbers
+        cold_prefill: If True, stop the daemon-side runner before the request
+            so Ollama's KV cache reuse cannot inflate prompt-processing numbers
         timeout: subprocess timeout in seconds
 
     Returns:
@@ -239,17 +257,25 @@ def run_cli_benchmark(
     with open(context_file) as f:
         prompt = f.read()
 
-    # Bust Ollama's prompt cache by prepending a unique marker so no two
-    # prompts share a prefix. Adds ~10 tokens of overhead.
-    if cold_prefill:
-        prompt = _make_cache_buster() + prompt
-    elif _run_idx is not None:
+    # Cached mode uses one deterministic prefix per run so different runs are
+    # isolated while nested context sizes within a run can reuse KV state.
+    # Cold mode resets the daemon-side runner instead of relying on a prefix.
+    if not cold_prefill and _run_idx is not None:
         prompt = _make_cache_buster(run_idx=_run_idx) + prompt
 
     # Pipe the prompt via stdin instead of passing it as argv. The old
     # `ollama run model --verbose "prompt"` form hit ARG_MAX (~256KB on macOS)
     # for anything above ~60k tokens. stdin has no size limit.
     cmd = ["ollama", "run", model_name, "--verbose"]
+    if cold_prefill:
+        try:
+            _stop_model(model_name)
+        except Exception as e:
+            print(f"Error clearing Ollama prompt cache before cold prefill: {e}")
+            return None
+        # Ensure the runner is unloaded after this request as well. This makes
+        # isolation robust if the benchmark is interrupted between trials.
+        cmd.extend(["--keepalive", "0"])
 
     start_time = time.time()
 
@@ -535,8 +561,8 @@ def main() -> int:
         "--cold-prefill",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Prepend a unique marker to every prompt to bust Ollama's KV "
-        "cache reuse, forcing cold prefill on every row (default: enabled; "
+        help="Stop the Ollama runner before every prompt to discard its KV "
+        "cache, forcing cold prefill on every row (default: enabled; "
         "use --no-cold-prefill for cached/warm-reuse numbers)",
     )
 
@@ -595,7 +621,7 @@ def main() -> int:
     print(f"Model: {args.model}")
     print(f"Max tokens: {args.max_tokens}")
     print(
-        f"Cold prefill: {'enabled (cache busted per prompt)' if args.cold_prefill else 'disabled (cache reuse allowed)'}"
+        f"Cold prefill: {'enabled (runner reset per prompt)' if args.cold_prefill else 'disabled (cache reuse allowed)'}"
     )
 
     # Ollama run has no --num-ctx or --num-predict flag, so we create a
@@ -644,6 +670,7 @@ def main() -> int:
                     cold_prefill=args.cold_prefill,
                     timeout=args.timeout,
                     n_runs=args.runs,
+                    reject_prefill_cache_hits=True,
                 )
                 if result:
                     results.append(result)


### PR DESCRIPTION
## Summary

- unload the Ollama runner before every cold-prefill API and CLI trial
- keep warm-cache runs isolated by run-specific prompt prefixes
- reject likely prompt-cache hits before selecting peak benchmark results

## Verification

- `uv run pre-commit run --files benchmark_common.py ollama_api_benchmark.py ollama_cli_benchmark.py`
- `uv run python -m py_compile benchmark_common.py ollama_api_benchmark.py ollama_cli_benchmark.py`