### PR TITLE
Fix web UI model discovery routing

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -336,6 +336,8 @@ def api_endpoints_update(endpoint_id: str, payload: dict):
 def api_models(payload: dict):
     """Discover available models on an inference server (OpenAI /v1/models or Ollama /api/tags)."""
     engine = payload.get("engine") or ""
+    engine_info = get_engine_catalog().get(engine) or {}
+    connection_kind = engine_info.get("connection")
     base_url = (payload.get("base_url") or "").strip()
     host = (payload.get("host") or "").strip()
     port = payload.get("port") or ""
@@ -343,12 +345,14 @@ def api_models(payload: dict):
 
     if engine in ("ollama-api", "ollama-cli"):
         url, flavor = "http://127.0.0.1:11434/api/tags", "ollama"
-    elif host:
+    elif connection_kind == "hostport" and host:
         url, flavor = f"http://{host}:{port or 8080}/v1/models", "openai"
     elif base_url:
         trimmed = base_url.rstrip("/")
         url = trimmed + "/models" if trimmed.endswith("/v1") else trimmed + "/v1/models"
         flavor = "openai"
+    elif host:
+        url, flavor = f"http://{host}:{port or 8080}/v1/models", "openai"
     else:
         return {"models": [], "detail": "No connection configured"}
 

--- a/webui_static/view-endpoints.js
+++ b/webui_static/view-endpoints.js
@@ -211,6 +211,7 @@
 
     const epConnection = () => {
       const engineId = modal.querySelector("#epEngine").value;
+      const engine = engineById(engineId);
       const connection = {
         engine: engineId,
         base_url: modal.querySelector("#epBaseUrl").value.trim(),
@@ -218,6 +219,12 @@
         host: modal.querySelector("#epHost").value.trim(),
         port: modal.querySelector("#epPort").value,
       };
+      if (engine && engine.connection === "base_url") {
+        connection.host = "";
+        connection.port = "";
+      } else if (engine && engine.connection === "hostport") {
+        connection.base_url = "";
+      }
       const ollama = engineId === "ollama-api" || engineId === "ollama-cli";
       if (!ollama && !connection.base_url && !connection.host) return null;
       return connection;

--- a/webui_static/view-run.js
+++ b/webui_static/view-run.js
@@ -209,10 +209,18 @@
     // like readConnection, but with the engine defaults filled in so model
     // discovery can hit the server before the user typed anything
     const runConnection = () => {
+      // Local engines do not have an HTTP endpoint.  readConnection() still
+      // carries the form's default host/port, which would otherwise make the
+      // model picker probe localhost:8080 instead of using local discovery.
+      if (!engine.connection) return null;
       const connection = { engine: engine.id, ...readConnection(ep) };
-      if (!ep) {
-        if ("base_url" in connection) connection.base_url = connection.base_url || engine.default_base_url || "";
-        if ("host" in connection) connection.host = connection.host || "localhost";
+      if (engine.connection === "base_url") {
+        connection.base_url = connection.base_url || engine.default_base_url || "";
+        connection.host = "";
+        connection.port = "";
+      } else if (engine.connection === "hostport") {
+        connection.base_url = "";
+        connection.host = connection.host || "localhost";
       }
       const ollama = engine.id === "ollama-api" || engine.id === "ollama-cli";
       if (!ollama && !connection.base_url && !connection.host) return null;


### PR DESCRIPTION
Fix model discovery for local MLX and OpenAI-compatible base-URL engines such as oMLX. Local engines no longer probe stale localhost endpoints, and base-URL engines ignore hidden host/port defaults during discovery.